### PR TITLE
Support env vars in containers

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -49,11 +49,12 @@ func (d *docker) pullImage(ctx context.Context, image string) error {
 	return nil
 }
 
-func (d *docker) startContainer(ctx context.Context, image string, namedPorts NamedPorts) (*Container, error) {
-	exposedPorts := d.exposedPorts(namedPorts)
+func (d *docker) startContainer(ctx context.Context, image string, ports NamedPorts, cfg *options) (*Container, error) {
+	exposedPorts := d.exposedPorts(ports)
 	containerConfig := &container.Config{
 		Image:        image,
 		ExposedPorts: exposedPorts,
+		Env:          cfg.env,
 	}
 	portBindings := d.portBindings(exposedPorts)
 	hostConfig := &container.HostConfig{PortBindings: portBindings}
@@ -73,7 +74,7 @@ func (d *docker) startContainer(ctx context.Context, image string, namedPorts Na
 		return nil, fmt.Errorf("can't inspect container %s: %w", resp.ID, err)
 	}
 
-	boundNamedPorts, err := d.boundNamedPorts(containerJSON, namedPorts)
+	boundNamedPorts, err := d.boundNamedPorts(containerJSON, ports)
 	if err != nil {
 		return nil, fmt.Errorf("can't find bound ports: %w", err)
 	}

--- a/gnomock.go
+++ b/gnomock.go
@@ -37,7 +37,7 @@ func Start(image string, ports NamedPorts, opts ...Option) (c *Container, err er
 		return nil, fmt.Errorf("can't pull image: %w", err)
 	}
 
-	c, err = cli.startContainer(startCtx, image, ports)
+	c, err = cli.startContainer(startCtx, image, ports, config)
 	if err != nil {
 		return nil, fmt.Errorf("can't start container: %w", err)
 	}

--- a/options.go
+++ b/options.go
@@ -69,6 +69,14 @@ func WithWaitTimeout(t time.Duration) Option {
 	}
 }
 
+// WithEnv adds environment variable to the container. For example,
+// AWS_ACCESS_KEY_ID=FOOBARBAZ
+func WithEnv(env string) Option {
+	return func(o *options) {
+		o.env = append(o.env, env)
+	}
+}
+
 // HealthcheckFunc defines a function to be used to determine container health.
 // It receives a host and a port, and returns an error if the container is not
 // ready, or nil when the container can be used. One example of HealthcheckFunc
@@ -96,6 +104,7 @@ type options struct {
 	healthcheckInterval time.Duration
 	startTimeout        time.Duration
 	waitTimeout         time.Duration
+	env                 []string
 }
 
 func buildConfig(opts ...Option) *options {


### PR DESCRIPTION
This PR adds support for custom env vars in containers using `gnomock.WithEnv` function.