### PR TITLE
Support forwarding logs

### DIFF
--- a/container.go
+++ b/container.go
@@ -11,6 +11,8 @@ type Container struct {
 	ID    string
 	Host  string
 	Ports NamedPorts
+
+	onStop func() error
 }
 
 // Address is a convenience function that returns host:port that can be used to

--- a/docker.go
+++ b/docker.go
@@ -3,6 +3,7 @@ package gnomock
 import (
 	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"strconv"
 	"time"
@@ -140,6 +141,19 @@ func (d *docker) boundNamedPorts(json types.ContainerJSON, namedPorts NamedPorts
 	}
 
 	return boundNamedPorts, nil
+}
+
+func (d *docker) readLogs(ctx context.Context, id string) (io.ReadCloser, error) {
+	logsOptions := types.ContainerLogsOptions{
+		ShowStderr: true, ShowStdout: true, Follow: true,
+	}
+
+	rc, err := d.client.ContainerLogs(ctx, id, logsOptions)
+	if err != nil {
+		return nil, fmt.Errorf("can't read logs: %w", err)
+	}
+
+	return rc, nil
 }
 
 func (d *docker) stopContainer(ctx context.Context, id string) error {

--- a/gnomock_test.go
+++ b/gnomock_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"testing"
@@ -136,6 +137,34 @@ func TestGnomock_cantStart(t *testing.T) {
 	defer func() { require.NoError(t, gnomock.Stop(container)) }()
 
 	require.Error(t, err)
+}
+
+func TestGnomock_withLogWriter(t *testing.T) {
+	t.Parallel()
+
+	r, w := io.Pipe()
+
+	container, err := gnomock.Start(
+		testImage, gnomock.DefaultTCP(goodPort80),
+		gnomock.WithLogWriter(w),
+	)
+	require.NoError(t, err)
+
+	signal := make(chan struct{})
+
+	go func() {
+		defer close(signal)
+
+		log, err := ioutil.ReadAll(r)
+		require.NoError(t, err)
+		require.Equal(t, "starting with env1 = '', env2 = ''\n", string(log))
+	}()
+
+	require.NoError(t, gnomock.Stop(container))
+
+	require.NoError(t, w.Close())
+	<-signal
+	require.NoError(t, r.Close())
 }
 
 func healthcheck(c *gnomock.Container) error {

--- a/gnomock_test.go
+++ b/gnomock_test.go
@@ -125,6 +125,19 @@ func TestGnomock_initError(t *testing.T) {
 	require.True(t, errors.Is(err, errNope))
 }
 
+func TestGnomock_cantStart(t *testing.T) {
+	t.Parallel()
+
+	container, err := gnomock.Start(
+		"docker.io/orlangure/noimage",
+		gnomock.DefaultTCP(goodPort80),
+	)
+
+	defer func() { require.NoError(t, gnomock.Stop(container)) }()
+
+	require.Error(t, err)
+}
+
 func healthcheck(c *gnomock.Container) error {
 	err := callRoot(fmt.Sprintf("http://%s/", c.Address("web80")))
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/net v0.0.0-20190923162816-aa69164e4478 // indirect
+	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 	golang.org/x/sys v0.0.0-20191010194322-b09406accb47 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190923162816-aa69164e4478 h1:l5EDrHhldLYb3ZRHDUhXF7Om7MvYXnkV9/iQNo1lX6g=
 golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a h1:WXEvlFVvvGxCJLG6REjsT03iWnKLEWinaScsxF2Vm2o=
+golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/options.go
+++ b/options.go
@@ -2,6 +2,8 @@ package gnomock
 
 import (
 	"context"
+	"io"
+	"io/ioutil"
 	"time"
 )
 
@@ -77,6 +79,14 @@ func WithEnv(env string) Option {
 	}
 }
 
+// WithLogWriter sets the target where to write container logs. This can be
+// useful for debugging
+func WithLogWriter(w io.Writer) Option {
+	return func(o *options) {
+		o.logWriter = w
+	}
+}
+
 // HealthcheckFunc defines a function to be used to determine container health.
 // It receives a host and a port, and returns an error if the container is not
 // ready, or nil when the container can be used. One example of HealthcheckFunc
@@ -105,6 +115,7 @@ type options struct {
 	startTimeout        time.Duration
 	waitTimeout         time.Duration
 	env                 []string
+	logWriter           io.Writer
 }
 
 func buildConfig(opts ...Option) *options {
@@ -115,6 +126,7 @@ func buildConfig(opts ...Option) *options {
 		healthcheckInterval: defaultHealthcheckInterval,
 		startTimeout:        defaultStartTimeout,
 		waitTimeout:         defaultWaitTimeout,
+		logWriter:           ioutil.Discard,
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
By default, all container logs are discarded. To forward container logs wherever needed, `WithLogWriter` function should be used with any kind of `io.Writer`.

Closes #9 