### PR TITLE
Allow direct configuration without Option funcs

### DIFF
--- a/container.go
+++ b/container.go
@@ -8,9 +8,9 @@ import (
 // fields should be used to configure the connection to this container. ID
 // matches the original docker container ID
 type Container struct {
-	ID    string
-	Host  string
-	Ports NamedPorts
+	ID    string     `json:"id,omitempty"`
+	Host  string     `json:"host,omitempty"`
+	Ports NamedPorts `json:"ports,omitempty"`
 
 	onStop func() error
 }

--- a/docker.go
+++ b/docker.go
@@ -52,12 +52,12 @@ func (d *docker) pullImage(ctx context.Context, image string) error {
 	return nil
 }
 
-func (d *docker) startContainer(ctx context.Context, image string, ports NamedPorts, cfg *options) (*Container, error) {
+func (d *docker) startContainer(ctx context.Context, image string, ports NamedPorts, cfg *Options) (*Container, error) {
 	exposedPorts := d.exposedPorts(ports)
 	containerConfig := &container.Config{
 		Image:        image,
 		ExposedPorts: exposedPorts,
-		Env:          cfg.env,
+		Env:          cfg.Env,
 	}
 	portBindings := d.portBindings(exposedPorts)
 	hostConfig := &container.HostConfig{

--- a/options.go
+++ b/options.go
@@ -14,12 +14,12 @@ const defaultHealthcheckInterval = time.Millisecond * 50
 // Option is an optional Gnomock configuration. Functions implementing this
 // signature may be combined to configure Gnomock containers for different use
 // cases
-type Option func(*options)
+type Option func(*Options)
 
 // WithContext sets the provided context to be used for setting up a Gnomock
 // container. Canceling this context will cause Start() to abort
 func WithContext(ctx context.Context) Option {
-	return func(o *options) {
+	return func(o *Options) {
 		o.ctx = ctx
 	}
 }
@@ -29,7 +29,7 @@ func WithContext(ctx context.Context) Option {
 // on the new container before using it. It can be useful to bring the
 // container to a certain state (e.g create SQL schema)
 func WithInit(f InitFunc) Option {
-	return func(o *options) {
+	return func(o *Options) {
 		o.init = f
 	}
 }
@@ -39,7 +39,7 @@ func WithInit(f InitFunc) Option {
 // return an error on any failure, or nil on success. This function is called
 // repeatedly until the timeout is reached, or until a nil error is returned
 func WithHealthCheck(f HealthcheckFunc) Option {
-	return func(o *options) {
+	return func(o *Options) {
 		o.healthcheck = f
 	}
 }
@@ -47,7 +47,7 @@ func WithHealthCheck(f HealthcheckFunc) Option {
 // WithHealthCheckInterval defines an interval between two consecutive health
 // check calls. This is a constant interval
 func WithHealthCheckInterval(t time.Duration) Option {
-	return func(o *options) {
+	return func(o *Options) {
 		o.healthcheckInterval = t
 	}
 }
@@ -57,8 +57,8 @@ func WithHealthCheckInterval(t time.Duration) Option {
 // it. To set the amount of time to wait before a created container healthy and
 // ready to use, use WithWaitTimeout
 func WithStartTimeout(t time.Duration) Option {
-	return func(o *options) {
-		o.startTimeout = t
+	return func(o *Options) {
+		o.StartTimeout = t
 	}
 }
 
@@ -66,31 +66,54 @@ func WithStartTimeout(t time.Duration) Option {
 // become ready to use. If health check function does not return nil error
 // until this timeout is reached, Start() fails
 func WithWaitTimeout(t time.Duration) Option {
-	return func(o *options) {
-		o.waitTimeout = t
+	return func(o *Options) {
+		o.WaitTimeout = t
 	}
 }
 
 // WithEnv adds environment variable to the container. For example,
 // AWS_ACCESS_KEY_ID=FOOBARBAZ
 func WithEnv(env string) Option {
-	return func(o *options) {
-		o.env = append(o.env, env)
+	return func(o *Options) {
+		o.Env = append(o.Env, env)
 	}
 }
 
 // WithLogWriter sets the target where to write container logs. This can be
 // useful for debugging
 func WithLogWriter(w io.Writer) Option {
-	return func(o *options) {
+	return func(o *Options) {
 		o.logWriter = w
 	}
 }
 
 // WithTag overrides docker image tag provided by a preset
 func WithTag(tag string) Option {
-	return func(o *options) {
-		o.tag = tag
+	return func(o *Options) {
+		o.Tag = tag
+	}
+}
+
+// WithOptions allows to provide an existing set of Options instead of using
+// optional configuration.
+//
+// This way has its own limitations. For example, context or initialization
+// functions cannot be set in this way
+func WithOptions(options *Options) Option {
+	return func(o *Options) {
+		if options.StartTimeout > 0 {
+			o.StartTimeout = options.StartTimeout
+		}
+
+		if options.WaitTimeout > 0 {
+			o.WaitTimeout = options.WaitTimeout
+		}
+
+		if options.Tag != "" {
+			o.Tag = options.Tag
+		}
+
+		o.Env = append(o.Env, options.Env...)
 	}
 }
 
@@ -114,28 +137,45 @@ func nopInit(*Container) error {
 	return nil
 }
 
-type options struct {
+// Options includes Gnomock startup configuration. Functional options
+// (WithSomething) should be used instead of directly initializing objects of
+// this type whenever possible
+type Options struct {
+	// StartTimeout is an amount of nanoseconds to wait for the container to be
+	// created. This includes the time to pull docker image, create and start
+	// the container. It does not include the time to wait for the container to
+	// become healthy
+	StartTimeout time.Duration `json:"start_timeout"`
+
+	// WaitTimeout is an amount of nanoseconds to wait for a created container
+	// to become healthy and ready to use
+	WaitTimeout time.Duration `json:"wait_timeout"`
+
+	// Env is a list of environment variable to inject into the container. Each
+	// entry is in format ENV_VAR_NAME=value
+	Env []string `json:"env"`
+
+	// Tag sets docker image version to be used in this container. By default,
+	// latest tag is used
+	Tag string `json:"tag"`
+
 	ctx                 context.Context
 	init                InitFunc
 	healthcheck         HealthcheckFunc
 	healthcheckInterval time.Duration
-	startTimeout        time.Duration
-	waitTimeout         time.Duration
-	env                 []string
 	logWriter           io.Writer
-	tag                 string
 }
 
-func buildConfig(opts ...Option) *options {
-	config := &options{
+func buildConfig(opts ...Option) *Options {
+	config := &Options{
 		ctx:                 context.Background(),
 		init:                nopInit,
 		healthcheck:         nopHealthcheck,
 		healthcheckInterval: defaultHealthcheckInterval,
-		startTimeout:        defaultStartTimeout,
-		waitTimeout:         defaultWaitTimeout,
+		StartTimeout:        defaultStartTimeout,
+		WaitTimeout:         defaultWaitTimeout,
 		logWriter:           ioutil.Discard,
-		tag:                 "",
+		Tag:                 "",
 	}
 
 	for _, opt := range opts {

--- a/ports.go
+++ b/ports.go
@@ -17,10 +17,10 @@ var ErrPortNotFound = errors.New("port not found")
 // container
 type Port struct {
 	// Protocol of the exposed port (TCP/UDP)
-	Protocol string
+	Protocol string `json:"protocol"`
 
 	// Port number of the exposed port
-	Port int
+	Port int `json:"port"`
 }
 
 // DefaultTCP is a utility function to use with simple containers exposing a


### PR DESCRIPTION
This PR allows to configure Gnomock using a single object, instead of a requirement to use functional options.