### PR TITLE
Fix "bad connection" in mysql preset

### DIFF
--- a/preset/mysql/preset.go
+++ b/preset/mysql/preset.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"time"
 
 	mysqldriver "github.com/go-sql-driver/mysql"
 	"github.com/orlangure/gnomock"
@@ -64,7 +63,6 @@ func (p *P) Options() []gnomock.Option {
 		gnomock.WithEnv("MYSQL_DATABASE=" + p.DB),
 		gnomock.WithEnv("MYSQL_RANDOM_ROOT_PASSWORD=yes"),
 		gnomock.WithInit(p.initf()),
-		gnomock.WithWaitTimeout(time.Second * 30),
 	}
 
 	return opts
@@ -142,10 +140,7 @@ func (p *P) connect(addr string) (*sql.DB, error) {
 		return nil, err
 	}
 
-	// attempt to solve "driver: bad connection issue"
-	db.SetConnMaxLifetime(time.Second * 10)
-
-	return db, nil
+	return db, db.Ping()
 }
 
 func (p *P) setDefaults() {

--- a/preset/postgres/preset.go
+++ b/preset/postgres/preset.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 	"io/ioutil"
-	"time"
 
 	_ "github.com/lib/pq" // postgres driver
 	"github.com/orlangure/gnomock"
@@ -160,7 +159,5 @@ func connect(c *gnomock.Container, db string) (*sql.DB, error) {
 		return nil, err
 	}
 
-	conn.SetConnMaxLifetime(time.Second * 10)
-
-	return conn, nil
+	return conn, conn.Ping()
 }


### PR DESCRIPTION
Many builds failed due to a "bad connection" error that was caused by a
short wait timeout (30 seconds). In environments like github actions
setting up mysql container takes more time, so this option was removed
in favor of default gnomock options (much higher at this moment).

This commit also adds a Ping call to reestablish a connection in case it
was closed by the server.