### PR TITLE
Merge timeouts into a single timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,9 +157,9 @@ docker pull postgres:11
 
 It can happen if the containers can't become ready to use before they time out.
 By default, Gnomock uses fairly high timeouts for new containers (for starting
-and for setting them up). If you choose to change default timeouts using
-`WithWaitTimeout` (`wait_timeout` in HTTP) or `WithInitTimeout` (`init_timeout`
-in HTTP), it is possible that the values you choose are too short.
+and for setting them up). If you choose to change default timeout using
+`WithTimeout` (`timeout` in HTTP), it is possible that the values you choose
+are too short.
 
 ### Tests pass when run one-by-one, and fail when run in parallel
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ creation, test data upload into S3, sending test events to Splunk, etc.
 
 Gnomock runs locally and exposes an API over HTTP. This API is defined using
 OpenAPI 3.0
-[specification](https://app.swaggerhub.com/apis/orlangure/gnomock/1.0.1). Go
+[specification](https://app.swaggerhub.com/apis/orlangure/gnomock/1.1.1). Go
 programs can use extended Gnomock package directly, without HTTP layer, while
 other languages require communication with a local server.
 
@@ -68,7 +68,7 @@ For Preset documentation, refer to [Presets](#official-presets) section.
 
 Gnomock runs as a local server, and any program in any language can communicate
 with it using OpenAPI 3.0
-[specification](https://app.swaggerhub.com/apis/orlangure/gnomock/1.0.1).
+[specification](https://app.swaggerhub.com/apis/orlangure/gnomock/1.1.1).
 
 Below is an example of setting up a **MySQL** container using a `POST` request:
 
@@ -111,7 +111,7 @@ There are auto-generated wrappers for the available API:
 - [Other](https://openapi-generator.tech/docs/generators) languages
 
 **For more details and a full specification, see
-[documentation](https://app.swaggerhub.com/apis/orlangure/gnomock/1.0.1).**
+[documentation](https://app.swaggerhub.com/apis/orlangure/gnomock/1.1.1).**
 
 Installation instruction, as well as pre-compiled binaries for MacOS and Linux,
 are coming soon.
@@ -123,13 +123,13 @@ listed below:
 
 | Preset | Go package | HTTP API | Go API |
 |--------|------------|----------|-----------|
-Localstack | https://github.com/orlangure/gnomock/tree/master/preset/localstack | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.0.1#/presets/startLocalstack) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/localstack?tab=doc)
-Splunk | https://github.com/orlangure/gnomock/tree/master/preset/splunk | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.0.1#/presets/startSplunk) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/splunk?tab=doc)
-Redis | https://github.com/orlangure/gnomock/tree/master/preset/redis | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.0.1#/presets/startRedis) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/redis?tab=doc)
-MySQL | https://github.com/orlangure/gnomock/tree/master/preset/mysql | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.0.1#/presets/startMysql) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/mysql?tab=doc)
-PostgreSQL | https://github.com/orlangure/gnomock/tree/master/preset/postgres | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.0.1#/presets/startPostgres) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/postgres?tab=doc)
-Microsoft SQL Server | https://github.com/orlangure/gnomock/tree/master/preset/mssql | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.0.1#/presets/startMssql) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/mssql?tab=doc)
-MongoDB | https://github.com/orlangure/gnomock/tree/master/preset/mongo | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.0.1#/presets/startMongo) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/mongo?tab=doc)
+Localstack | https://github.com/orlangure/gnomock/tree/master/preset/localstack | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.1.1#/presets/startLocalstack) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/localstack?tab=doc)
+Splunk | https://github.com/orlangure/gnomock/tree/master/preset/splunk | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.1.1#/presets/startSplunk) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/splunk?tab=doc)
+Redis | https://github.com/orlangure/gnomock/tree/master/preset/redis | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.1.1#/presets/startRedis) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/redis?tab=doc)
+MySQL | https://github.com/orlangure/gnomock/tree/master/preset/mysql | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.1.1#/presets/startMysql) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/mysql?tab=doc)
+PostgreSQL | https://github.com/orlangure/gnomock/tree/master/preset/postgres | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.1.1#/presets/startPostgres) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/postgres?tab=doc)
+Microsoft SQL Server | https://github.com/orlangure/gnomock/tree/master/preset/mssql | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.1.1#/presets/startMssql) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/mssql?tab=doc)
+MongoDB | https://github.com/orlangure/gnomock/tree/master/preset/mongo | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.1.1#/presets/startMongo) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/mongo?tab=doc)
 Elasticsearch | |
 DynamoDB | |
 Cassandra | |

--- a/gnomock_test.go
+++ b/gnomock_test.go
@@ -35,8 +35,7 @@ func TestGnomock_happyFlow(t *testing.T) {
 		gnomock.WithHealthCheck(healthcheck),
 		gnomock.WithInit(initf),
 		gnomock.WithContext(context.Background()),
-		gnomock.WithStartTimeout(time.Second*30),
-		gnomock.WithWaitTimeout(time.Second*1),
+		gnomock.WithTimeout(time.Second*30),
 		gnomock.WithEnv("GNOMOCK_TEST_1=foo"),
 		gnomock.WithEnv("GNOMOCK_TEST_2=bar"),
 	)
@@ -59,7 +58,7 @@ func TestGnomock_wrongPort(t *testing.T) {
 	container, err := gnomock.StartCustom(
 		testImage, gnomock.DefaultTCP(badPort),
 		gnomock.WithHealthCheck(healthcheck),
-		gnomock.WithWaitTimeout(time.Millisecond*50),
+		gnomock.WithTimeout(time.Millisecond*50),
 	)
 	require.Error(t, err)
 	require.Nil(t, container)
@@ -103,7 +102,7 @@ func TestGnomock_initError(t *testing.T) {
 	t.Parallel()
 
 	errNope := fmt.Errorf("nope")
-	initWithErr := func(*gnomock.Container) error {
+	initWithErr := func(context.Context, *gnomock.Container) error {
 		return errNope
 	}
 
@@ -156,7 +155,7 @@ func TestGnomock_withLogWriter(t *testing.T) {
 	require.NoError(t, r.Close())
 }
 
-func healthcheck(c *gnomock.Container) error {
+func healthcheck(ctx context.Context, c *gnomock.Container) error {
 	err := callRoot(fmt.Sprintf("http://%s/", c.Address("web80")))
 	if err != nil {
 		return err
@@ -191,7 +190,7 @@ func callRoot(addr string) error {
 	return nil
 }
 
-func initf(*gnomock.Container) error {
+func initf(context.Context, *gnomock.Container) error {
 	return nil
 }
 

--- a/gnomockd/testdata/splunk.json
+++ b/gnomockd/testdata/splunk.json
@@ -3,7 +3,6 @@
         "values_file": "./testdata/splunk/events.jsonl",
         "admin_password": "12345678",
         "accept_license": true,
-        "version": "8.0.2.1",
-        "init_timeout": 60000000000
+        "version": "8.0.2.1"
     }
 }

--- a/preset/localstack/preset.go
+++ b/preset/localstack/preset.go
@@ -4,11 +4,11 @@
 package localstack
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/orlangure/gnomock"
 )
@@ -66,8 +66,6 @@ func (p *P) Options() []gnomock.Option {
 
 	opts := []gnomock.Option{
 		gnomock.WithHealthCheck(p.healthcheck(svcStrings)),
-		gnomock.WithStartTimeout(time.Second * 60 * 2),
-		gnomock.WithWaitTimeout(time.Second * 60),
 		gnomock.WithEnv("SERVICES=" + svcEnv),
 		gnomock.WithInit(p.initf()),
 	}
@@ -76,7 +74,7 @@ func (p *P) Options() []gnomock.Option {
 }
 
 func (p *P) healthcheck(services []string) gnomock.HealthcheckFunc {
-	return func(c *gnomock.Container) (err error) {
+	return func(ctx context.Context, c *gnomock.Container) (err error) {
 		addr := fmt.Sprintf("http://%s/health", c.Address(webPort))
 
 		res, err := http.Get(addr) //nolint:gosec
@@ -123,7 +121,7 @@ type healthResponse struct {
 }
 
 func (p *P) initf() gnomock.InitFunc {
-	return func(c *gnomock.Container) error {
+	return func(ctx context.Context, c *gnomock.Container) error {
 		for _, s := range p.Services {
 			if s == S3 {
 				err := p.initS3(c)

--- a/preset/mongo/preset.go
+++ b/preset/mongo/preset.go
@@ -71,7 +71,7 @@ func (p *P) Options() []gnomock.Option {
 	return opts
 }
 
-func (p *P) initf(c *gnomock.Container) error {
+func (p *P) initf(ctx context.Context, c *gnomock.Container) error {
 	addr := c.Address(gnomock.DefaultPort)
 	uri := "mongodb://" + addr
 
@@ -175,7 +175,7 @@ func (p *P) setupCollection(client *mongodb.Client, dirName, dataFileName string
 	}
 }
 
-func healthcheck(c *gnomock.Container) error {
+func healthcheck(ctx context.Context, c *gnomock.Container) error {
 	addr := c.Address(gnomock.DefaultPort)
 	clientOptions := mongooptions.Client().ApplyURI("mongodb://" + addr)
 

--- a/preset/mssql/preset.go
+++ b/preset/mssql/preset.go
@@ -2,10 +2,10 @@
 package mssql
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"io/ioutil"
-	"time"
 
 	_ "github.com/denisenkom/go-mssqldb" // mssql driver
 	"github.com/orlangure/gnomock"
@@ -59,7 +59,6 @@ func (p *P) Options() []gnomock.Option {
 		gnomock.WithHealthCheck(p.healthcheck),
 		gnomock.WithEnv("SA_PASSWORD=" + p.Password),
 		gnomock.WithInit(p.initf()),
-		gnomock.WithWaitTimeout(time.Second * 30),
 	}
 
 	if p.License {
@@ -69,7 +68,7 @@ func (p *P) Options() []gnomock.Option {
 	return opts
 }
 
-func (p *P) healthcheck(c *gnomock.Container) error {
+func (p *P) healthcheck(ctx context.Context, c *gnomock.Container) error {
 	addr := c.Address(gnomock.DefaultPort)
 
 	db, err := p.connect(addr, masterDB)
@@ -98,7 +97,7 @@ func (p *P) healthcheck(c *gnomock.Container) error {
 }
 
 func (p *P) initf() gnomock.InitFunc {
-	return func(c *gnomock.Container) error {
+	return func(ctx context.Context, c *gnomock.Container) error {
 		addr := c.Address(gnomock.DefaultPort)
 
 		db, err := p.connect(addr, masterDB)

--- a/preset/mysql/preset.go
+++ b/preset/mysql/preset.go
@@ -2,6 +2,7 @@
 package mysql
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"io/ioutil"
@@ -68,7 +69,7 @@ func (p *P) Options() []gnomock.Option {
 	return opts
 }
 
-func (p *P) healthcheck(c *gnomock.Container) error {
+func (p *P) healthcheck(ctx context.Context, c *gnomock.Container) error {
 	addr := c.Address(gnomock.DefaultPort)
 
 	db, err := p.connect(addr)
@@ -97,7 +98,7 @@ func (p *P) healthcheck(c *gnomock.Container) error {
 }
 
 func (p *P) initf() gnomock.InitFunc {
-	return func(c *gnomock.Container) error {
+	return func(ctx context.Context, c *gnomock.Container) error {
 		addr := c.Address(gnomock.DefaultPort)
 
 		db, err := p.connect(addr)

--- a/preset/postgres/preset.go
+++ b/preset/postgres/preset.go
@@ -2,6 +2,7 @@
 package postgres
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"io/ioutil"
@@ -70,7 +71,7 @@ func (p *P) Options() []gnomock.Option {
 	return opts
 }
 
-func (p *P) healthcheck(c *gnomock.Container) error {
+func (p *P) healthcheck(ctx context.Context, c *gnomock.Container) error {
 	db, err := connect(c, defaultDatabase)
 	if err != nil {
 		return err
@@ -97,7 +98,7 @@ func (p *P) healthcheck(c *gnomock.Container) error {
 }
 
 func (p *P) initf() gnomock.InitFunc {
-	return func(c *gnomock.Container) error {
+	return func(ctx context.Context, c *gnomock.Container) error {
 		if p.DB != defaultDatabase {
 			db, err := connect(c, defaultDatabase)
 			if err != nil {

--- a/preset/redis/preset.go
+++ b/preset/redis/preset.go
@@ -4,6 +4,7 @@
 package redis
 
 import (
+	"context"
 	"fmt"
 
 	redisclient "github.com/go-redis/redis/v7"
@@ -45,7 +46,7 @@ func (r *P) Options() []gnomock.Option {
 	}
 
 	if r.Values != nil {
-		initf := func(c *gnomock.Container) error {
+		initf := func(ctx context.Context, c *gnomock.Container) error {
 			addr := c.Address(gnomock.DefaultPort)
 			client := redisclient.NewClient(&redisclient.Options{Addr: addr})
 
@@ -65,7 +66,7 @@ func (r *P) Options() []gnomock.Option {
 	return opts
 }
 
-func healthcheck(c *gnomock.Container) error {
+func healthcheck(ctx context.Context, c *gnomock.Container) error {
 	addr := c.Address(gnomock.DefaultPort)
 	client := redisclient.NewClient(&redisclient.Options{Addr: addr})
 	_, err := client.Ping().Result()

--- a/preset/splunk/README.md
+++ b/preset/splunk/README.md
@@ -38,7 +38,6 @@ func ExamplePreset() {
 		splunk.WithLicense(true),
 		splunk.WithPassword("12345678"),
 		splunk.WithValues(events),
-		splunk.WithInitTimeout(time.Second*10),
 	)
 
 	// created container now includes two events in "events" index

--- a/preset/splunk/init.go
+++ b/preset/splunk/init.go
@@ -42,10 +42,7 @@ type Event struct {
 }
 
 func (p *P) initf() gnomock.InitFunc {
-	return func(c *gnomock.Container) (err error) {
-		ctx, cancel := context.WithTimeout(context.Background(), p.InitTimeout)
-		defer cancel()
-
+	return func(ctx context.Context, c *gnomock.Container) (err error) {
 		if p.ValuesFile != "" {
 			f, err := os.Open(p.ValuesFile)
 			if err != nil {

--- a/preset/splunk/options.go
+++ b/preset/splunk/options.go
@@ -1,7 +1,5 @@
 package splunk
 
-import "time"
-
 // Option is an optional configuration of this Gnomock preset. Use available
 // Options to configure the container
 type Option func(*P)
@@ -47,14 +45,5 @@ func WithLicense(accept bool) Option {
 func WithPassword(pass string) Option {
 	return func(o *P) {
 		o.AdminPassword = pass
-	}
-}
-
-// WithInitTimeout sets the duration to wait before giving up on trying to
-// initialize this Splunk container. This option is only useful when WithValues
-// is used. Default value is 5 seconds
-func WithInitTimeout(timeout time.Duration) Option {
-	return func(o *P) {
-		o.InitTimeout = timeout
 	}
 }

--- a/preset/splunk/preset_test.go
+++ b/preset/splunk/preset_test.go
@@ -49,7 +49,6 @@ func TestPreset(t *testing.T) {
 		splunk.WithLicense(true),
 		splunk.WithPassword("12345678"),
 		splunk.WithValues(events),
-		splunk.WithInitTimeout(time.Second*20),
 	)
 	c, err := gnomock.Start(p)
 

--- a/preset_test.go
+++ b/preset_test.go
@@ -3,6 +3,7 @@
 package gnomock_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -37,7 +38,7 @@ func TestPreset(t *testing.T) {
 	t.Parallel()
 
 	p := &testPreset{testImage}
-	container, err := gnomock.Start(p, gnomock.WithStartTimeout(time.Second))
+	container, err := gnomock.Start(p, gnomock.WithTimeout(time.Second))
 
 	defer func(c *gnomock.Container) {
 		require.NoError(t, gnomock.Stop(c))
@@ -95,7 +96,7 @@ func (t *testPreset) Ports() gnomock.NamedPorts {
 // Preset implementation. This test preset always returns a failing healthcheck
 func (t *testPreset) Options() []gnomock.Option {
 	return []gnomock.Option{
-		gnomock.WithHealthCheck(func(*gnomock.Container) error {
+		gnomock.WithHealthCheck(func(context.Context, *gnomock.Container) error {
 			return fmt.Errorf("this container should not start")
 		}),
 	}

--- a/sdktest/python/requirements.txt
+++ b/sdktest/python/requirements.txt
@@ -2,7 +2,7 @@ apipkg==1.5
 attrs==19.3.0
 certifi==2020.4.5.1
 execnet==1.7.1
-gnomock-python-sdk==1.0.1
+gnomock-python-sdk==1.1.0
 importlib-metadata==1.6.0
 more-itertools==8.2.0
 packaging==20.3

--- a/sdktest/python/requirements.txt
+++ b/sdktest/python/requirements.txt
@@ -2,7 +2,7 @@ apipkg==1.5
 attrs==19.3.0
 certifi==2020.4.5.1
 execnet==1.7.1
-gnomock-python-sdk==1.1.0
+gnomock-python-sdk==1.1.2
 importlib-metadata==1.6.0
 more-itertools==8.2.0
 packaging==20.3

--- a/swagger/config/python.yaml
+++ b/swagger/config/python.yaml
@@ -1,4 +1,4 @@
 projectName: gnomock-python-sdk
 projectUrl: https://github.com/orlangure/gnomock
 packageName: gnomock
-packageVersion: 1.1.1
+packageVersion: 1.1.2

--- a/swagger/config/python.yaml
+++ b/swagger/config/python.yaml
@@ -1,4 +1,4 @@
 projectName: gnomock-python-sdk
 projectUrl: https://github.com/orlangure/gnomock
 packageName: gnomock
-packageVersion: 1.0.1
+packageVersion: 1.1.1

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -7,7 +7,7 @@ info:
     testing toolkit. It allows to use Gnomock outside of Go ecosystem. Not all
     Gnomock features exist in this wrapper, but official presets, as well as
     basic general configuration, are supported.
-  version: 0.1.1
+  version: 1.1.1
   contact:
     url: https://github.com/orlangure/gnomock/
   license:
@@ -260,18 +260,12 @@ components:
     options:
       type: object
       properties:
-        start_timeout:
-          type: integer
-          format: int64
-          description: Start timeout in nanoseconds
-          default: 60000000000
-          example: 120000000000
-        wait_timeout:
+        timeout:
           type: integer
           format: int64
           description: Wait timeout in nanoseconds
-          default: 10000000000
-          example: 30000000000
+          default: 300000000000
+          example: 60000000000
         env:
           type: array
           description: Array of environment variables to set in the container
@@ -597,13 +591,6 @@ components:
           type: string
           description: Set a password for `admin` user.
           example: p@s$w0rD
-        init_timeout:
-          type: number
-          format: double
-          example: 30000000000
-          default: 5000000000
-          description: >
-            Wait for the initialization for this number of nanoseconds.
         version:
           type: string
           description: Splunk version.


### PR DESCRIPTION
Instead of setting start, wait and init timeout (which existed only in
splunk), gnomock will now use a single timeout value shared by all
steps.

Closes #24 