### PR TITLE
Move preset image tag to each preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ creation, test data upload into S3, sending test events to Splunk, etc.
 
 Gnomock runs locally and exposes an API over HTTP. This API is defined using
 OpenAPI 3.0
-[specification](https://app.swaggerhub.com/apis/orlangure/gnomock/1.1.1). Go
+[specification](https://app.swaggerhub.com/apis/orlangure/gnomock/1.2.0). Go
 programs can use extended Gnomock package directly, without HTTP layer, while
 other languages require communication with a local server.
 
@@ -82,7 +82,7 @@ For Preset documentation, refer to [Presets](#official-presets) section.
 
 Gnomock runs as a local server, and any program in any language can communicate
 with it using OpenAPI 3.0
-[specification](https://app.swaggerhub.com/apis/orlangure/gnomock/1.1.1).
+[specification](https://app.swaggerhub.com/apis/orlangure/gnomock/).
 
 Below is an example of setting up a **MySQL** container using a `POST` request:
 
@@ -125,7 +125,7 @@ There are auto-generated wrappers for the available API:
 - [Other](https://openapi-generator.tech/docs/generators) languages
 
 **For more details and a full specification, see
-[documentation](https://app.swaggerhub.com/apis/orlangure/gnomock/1.1.1).**
+[documentation](https://app.swaggerhub.com/apis/orlangure/gnomock/).**
 
 Installation instruction, as well as pre-compiled binaries for MacOS and Linux,
 are coming soon.
@@ -137,13 +137,13 @@ listed below:
 
 | Preset | Go package | HTTP API | Go API |
 |--------|------------|----------|-----------|
-Localstack | https://github.com/orlangure/gnomock/tree/master/preset/localstack | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.1.1#/presets/startLocalstack) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/localstack?tab=doc)
-Splunk | https://github.com/orlangure/gnomock/tree/master/preset/splunk | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.1.1#/presets/startSplunk) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/splunk?tab=doc)
-Redis | https://github.com/orlangure/gnomock/tree/master/preset/redis | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.1.1#/presets/startRedis) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/redis?tab=doc)
-MySQL | https://github.com/orlangure/gnomock/tree/master/preset/mysql | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.1.1#/presets/startMysql) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/mysql?tab=doc)
-PostgreSQL | https://github.com/orlangure/gnomock/tree/master/preset/postgres | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.1.1#/presets/startPostgres) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/postgres?tab=doc)
-Microsoft SQL Server | https://github.com/orlangure/gnomock/tree/master/preset/mssql | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.1.1#/presets/startMssql) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/mssql?tab=doc)
-MongoDB | https://github.com/orlangure/gnomock/tree/master/preset/mongo | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.1.1#/presets/startMongo) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/mongo?tab=doc)
+Localstack | https://github.com/orlangure/gnomock/tree/master/preset/localstack | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.2.0#/presets/startLocalstack) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/localstack?tab=doc)
+Splunk | https://github.com/orlangure/gnomock/tree/master/preset/splunk | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.2.0#/presets/startSplunk) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/splunk?tab=doc)
+Redis | https://github.com/orlangure/gnomock/tree/master/preset/redis | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.2.0#/presets/startRedis) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/redis?tab=doc)
+MySQL | https://github.com/orlangure/gnomock/tree/master/preset/mysql | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.2.0#/presets/startMysql) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/mysql?tab=doc)
+PostgreSQL | https://github.com/orlangure/gnomock/tree/master/preset/postgres | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.2.0#/presets/startPostgres) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/postgres?tab=doc)
+Microsoft SQL Server | https://github.com/orlangure/gnomock/tree/master/preset/mssql | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.2.0#/presets/startMssql) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/mssql?tab=doc)
+MongoDB | https://github.com/orlangure/gnomock/tree/master/preset/mongo | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.2.0#/presets/startMongo) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/mongo?tab=doc)
 Elasticsearch | |
 DynamoDB | |
 Cassandra | |

--- a/gnomock.go
+++ b/gnomock.go
@@ -27,7 +27,7 @@ const defaultTag = "latest"
 // when no longer needed using its Stop() method
 func StartCustom(image string, ports NamedPorts, opts ...Option) (c *Container, err error) {
 	config := buildConfig(opts...)
-	image = buildImage(image, config.Tag)
+	image = buildImage(image)
 
 	ctx, cancel := context.WithTimeout(config.ctx, config.Timeout)
 	defer cancel()
@@ -166,18 +166,12 @@ func stop(c *Container) error {
 	return nil
 }
 
-func buildImage(image, tag string) string {
+func buildImage(image string) string {
 	parts := strings.Split(image, ":")
 
 	noTagSet := len(parts) == 1
 	if noTagSet {
-		if tag == "" {
-			tag = defaultTag
-		}
-
-		image = fmt.Sprintf("%s:%s", image, tag)
-	} else if tag != "" {
-		image = fmt.Sprintf("%s:%s", parts[0], tag)
+		image = fmt.Sprintf("%s:%s", parts[0], defaultTag)
 	}
 
 	return image

--- a/gnomockd/testdata/localstack.json
+++ b/gnomockd/testdata/localstack.json
@@ -3,9 +3,8 @@
         "s3_path": "./testdata/localstack/s3",
         "services":[
              "s3"
-        ]
+        ],
+        "version": "0.11.0"
     },
-    "options": {
-        "tag": "0.11.0"
-    }
+    "options": {}
 }

--- a/gnomockd/testdata/mongo.json
+++ b/gnomockd/testdata/mongo.json
@@ -2,9 +2,8 @@
     "preset": {
         "data_path": "./testdata/mongo",
         "user": "gnomock",
-        "password": "foobar"
+        "password": "foobar",
+        "version": "3"
     },
-    "options": {
-        "tag": "3"
-    }
+    "options": {}
 }

--- a/gnomockd/testdata/mssql.json
+++ b/gnomockd/testdata/mssql.json
@@ -7,9 +7,8 @@
         ],
         "password": "Passw0rd-",
         "db": "foobar",
-        "license": true
+        "license": true,
+        "version": "2019-latest"
     },
-    "options": {
-        "tag": "2019-latest"
-    }
+    "options": {}
 }

--- a/gnomockd/testdata/mysql.json
+++ b/gnomockd/testdata/mysql.json
@@ -7,9 +7,8 @@
         ],
         "user": "gnomock",
         "password": "foobar",
-        "db": "gnomockd_db"
+        "db": "gnomockd_db",
+        "version": "8"
     },
-    "options": {
-        "tag": "8"
-    }
+    "options": {}
 }

--- a/gnomockd/testdata/postgres.json
+++ b/gnomockd/testdata/postgres.json
@@ -7,9 +7,8 @@
         ],
         "user": "gnomock",
         "password": "foobar",
-        "db": "gnomockd_db"
+        "db": "gnomockd_db",
+        "version": "12"
     },
-    "options": {
-        "tag": "12"
-    }
+    "options": {}
 }

--- a/gnomockd/testdata/redis.json
+++ b/gnomockd/testdata/redis.json
@@ -3,9 +3,8 @@
         "values": {
             "answer": 42,
             "is_good": true
-        }
+        },
+        "version": "5"
     },
-    "options": {
-        "tag": "5"
-    }
+    "options": {}
 }

--- a/options.go
+++ b/options.go
@@ -76,13 +76,6 @@ func WithLogWriter(w io.Writer) Option {
 	}
 }
 
-// WithTag overrides docker image tag provided by a preset
-func WithTag(tag string) Option {
-	return func(o *Options) {
-		o.Tag = tag
-	}
-}
-
 // WithOptions allows to provide an existing set of Options instead of using
 // optional configuration.
 //
@@ -92,10 +85,6 @@ func WithOptions(options *Options) Option {
 	return func(o *Options) {
 		if options.Timeout > 0 {
 			o.Timeout = options.Timeout
-		}
-
-		if options.Tag != "" {
-			o.Tag = options.Tag
 		}
 
 		o.Env = append(o.Env, options.Env...)
@@ -134,10 +123,6 @@ type Options struct {
 	// entry is in format ENV_VAR_NAME=value
 	Env []string `json:"env"`
 
-	// Tag sets docker image version to be used in this container. By default,
-	// latest tag is used
-	Tag string `json:"tag"`
-
 	ctx                 context.Context
 	init                InitFunc
 	healthcheck         HealthcheckFunc
@@ -153,7 +138,6 @@ func buildConfig(opts ...Option) *Options {
 		healthcheckInterval: defaultHealthcheckInterval,
 		Timeout:             defaultTimeout,
 		logWriter:           ioutil.Discard,
-		Tag:                 "",
 	}
 
 	for _, opt := range opts {

--- a/preset/localstack/options.go
+++ b/preset/localstack/options.go
@@ -88,3 +88,10 @@ func WithServices(services ...Service) Option {
 		o.Services = append(o.Services, services...)
 	}
 }
+
+// WithVersion sets image version.
+func WithVersion(version string) Option {
+	return func(o *P) {
+		o.Version = version
+	}
+}

--- a/preset/localstack/preset.go
+++ b/preset/localstack/preset.go
@@ -20,6 +20,8 @@ const (
 	APIPort = "api"
 )
 
+const defaultVersion = "latest"
+
 // Preset creates a new localstack preset to use with gnomock.Start. See
 // package docs for a list of exposed ports and services. It is legal to not
 // provide any services using WithServices options, but in such case a new
@@ -40,11 +42,12 @@ func Preset(opts ...Option) gnomock.Preset {
 type P struct {
 	Services []Service `json:"services"`
 	S3Path   string    `json:"s3_path"`
+	Version  string    `json:"version"`
 }
 
 // Image returns an image that should be pulled to create this container
 func (p *P) Image() string {
-	return "docker.io/localstack/localstack"
+	return fmt.Sprintf("docker.io/localstack/localstack:%s", p.Version)
 }
 
 // Ports returns ports that should be used to access this container
@@ -57,6 +60,8 @@ func (p *P) Ports() gnomock.NamedPorts {
 
 // Options returns a list of options to configure this container
 func (p *P) Options() []gnomock.Option {
+	p.setDefaults()
+
 	svcStrings := make([]string, len(p.Services))
 	for i, svc := range p.Services {
 		svcStrings[i] = string(svc)
@@ -71,6 +76,12 @@ func (p *P) Options() []gnomock.Option {
 	}
 
 	return opts
+}
+
+func (p *P) setDefaults() {
+	if p.Version == "" {
+		p.Version = defaultVersion
+	}
 }
 
 func (p *P) healthcheck(services []string) gnomock.HealthcheckFunc {

--- a/preset/mongo/options.go
+++ b/preset/mongo/options.go
@@ -40,3 +40,10 @@ func WithUser(user, pass string) Option {
 		p.Password = pass
 	}
 }
+
+// WithVersion sets image version.
+func WithVersion(version string) Option {
+	return func(o *P) {
+		o.Version = version
+	}
+}

--- a/preset/mongo/preset.go
+++ b/preset/mongo/preset.go
@@ -20,6 +20,8 @@ import (
 	mongooptions "go.mongodb.org/mongo-driver/mongo/options"
 )
 
+const defaultVersion = "latest"
+
 // Preset creates a new Gmomock MongoDB preset. This preset includes a MongoDB
 // specific healthcheck function, default MongoDB image and port, and allows to
 // optionally set up initial state
@@ -38,11 +40,12 @@ type P struct {
 	DataPath string `json:"data_path"`
 	User     string `json:"user"`
 	Password string `json:"password"`
+	Version  string `json:"version"`
 }
 
 // Image returns an image that should be pulled to create this container
 func (p *P) Image() string {
-	return "docker.io/library/mongo"
+	return fmt.Sprintf("docker.io/library/mongo:%s", p.Version)
 }
 
 // Ports returns ports that should be used to access this container
@@ -52,6 +55,8 @@ func (p *P) Ports() gnomock.NamedPorts {
 
 // Options returns a list of options to configure this container
 func (p *P) Options() []gnomock.Option {
+	p.setDefaults()
+
 	opts := []gnomock.Option{
 		gnomock.WithHealthCheck(healthcheck),
 	}
@@ -69,6 +74,12 @@ func (p *P) Options() []gnomock.Option {
 	}
 
 	return opts
+}
+
+func (p *P) setDefaults() {
+	if p.Version == "" {
+		p.Version = defaultVersion
+	}
 }
 
 func (p *P) initf(ctx context.Context, c *gnomock.Container) error {

--- a/preset/mssql/options.go
+++ b/preset/mssql/options.go
@@ -45,3 +45,10 @@ func WithQueriesFile(file string) Option {
 		p.QueriesFile = file
 	}
 }
+
+// WithVersion sets image version.
+func WithVersion(version string) Option {
+	return func(o *P) {
+		o.Version = version
+	}
+}

--- a/preset/mssql/preset.go
+++ b/preset/mssql/preset.go
@@ -15,6 +15,7 @@ const masterDB = "master"
 const defaultPassword = "Gn0m!ck~"
 const defaultDatabase = "mydb"
 const defaultPort = 1433
+const defaultVersion = "latest"
 
 // Preset creates a new Gmomock Microsoft SQL Server preset. This preset
 // includes a mssql specific healthcheck function, default mssql image and
@@ -39,11 +40,12 @@ type P struct {
 	Queries     []string `json:"queries"`
 	QueriesFile string   `json:"queries_file"`
 	License     bool     `json:"license"`
+	Version     string   `json:"version"`
 }
 
 // Image returns an image that should be pulled to create this container
 func (p *P) Image() string {
-	return "mcr.microsoft.com/mssql/server"
+	return fmt.Sprintf("mcr.microsoft.com/mssql/server:%s", p.Version)
 }
 
 // Ports returns ports that should be used to access this container
@@ -155,5 +157,9 @@ func (p *P) setDefaults() {
 
 	if p.Password == "" {
 		p.Password = defaultPassword
+	}
+
+	if p.Version == "" {
+		p.Version = defaultVersion
 	}
 }

--- a/preset/mysql/options.go
+++ b/preset/mysql/options.go
@@ -37,3 +37,10 @@ func WithQueriesFile(file string) Option {
 		p.QueriesFile = file
 	}
 }
+
+// WithVersion sets image version.
+func WithVersion(version string) Option {
+	return func(o *P) {
+		o.Version = version
+	}
+}

--- a/preset/mysql/preset.go
+++ b/preset/mysql/preset.go
@@ -16,6 +16,7 @@ const defaultUser = "gnomock"
 const defaultPassword = "gnomick"
 const defaultDatabase = "mydb"
 const defaultPort = 3306
+const defaultVersion = "latest"
 
 // Preset creates a new Gmomock MySQL preset. This preset includes a MySQL
 // specific healthcheck function, default MySQL image and port, and allows to
@@ -38,11 +39,12 @@ type P struct {
 	Password    string   `json:"password"`
 	Queries     []string `json:"queries"`
 	QueriesFile string   `json:"queries_file"`
+	Version     string   `json:"version"`
 }
 
 // Image returns an image that should be pulled to create this container
 func (p *P) Image() string {
-	return "docker.io/library/mysql"
+	return fmt.Sprintf("docker.io/library/mysql:%s", p.Version)
 }
 
 // Ports returns ports that should be used to access this container
@@ -155,5 +157,9 @@ func (p *P) setDefaults() {
 
 	if p.Password == "" {
 		p.Password = defaultPassword
+	}
+
+	if p.Version == "" {
+		p.Version = defaultVersion
 	}
 }

--- a/preset/postgres/options.go
+++ b/preset/postgres/options.go
@@ -36,3 +36,10 @@ func WithQueriesFile(file string) Option {
 		p.QueriesFile = file
 	}
 }
+
+// WithVersion sets image version.
+func WithVersion(version string) Option {
+	return func(o *P) {
+		o.Version = version
+	}
+}

--- a/preset/postgres/preset.go
+++ b/preset/postgres/preset.go
@@ -16,6 +16,7 @@ const defaultPassword = "password"
 const defaultDatabase = "postgres"
 const defaultSSLMode = "disable"
 const defaultPort = 5432
+const defaultVersion = "latest"
 
 // Preset creates a new Gmomock Postgres preset. This preset includes a Postgres
 // specific healthcheck function, default Postgres image and port, and allows to
@@ -37,11 +38,12 @@ type P struct {
 	QueriesFile string   `json:"queries_file"`
 	User        string   `json:"user"`
 	Password    string   `json:"password"`
+	Version     string   `json:"version"`
 }
 
 // Image returns an image that should be pulled to create this container
 func (p *P) Image() string {
-	return "docker.io/library/postgres"
+	return fmt.Sprintf("docker.io/library/postgres:%s", p.Version)
 }
 
 // Ports returns ports that should be used to access this container
@@ -145,6 +147,10 @@ func (p *P) initf() gnomock.InitFunc {
 func (p *P) setDefaults() {
 	if p.DB == "" {
 		p.DB = defaultDatabase
+	}
+
+	if p.Version == "" {
+		p.Version = defaultVersion
 	}
 }
 

--- a/preset/redis/options.go
+++ b/preset/redis/options.go
@@ -12,3 +12,10 @@ func WithValues(vs map[string]interface{}) Option {
 		p.Values = vs
 	}
 }
+
+// WithVersion sets image version.
+func WithVersion(version string) Option {
+	return func(o *P) {
+		o.Version = version
+	}
+}

--- a/preset_test.go
+++ b/preset_test.go
@@ -57,19 +57,6 @@ func TestPreset(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestPreset_overrideTag(t *testing.T) {
-	t.Parallel()
-
-	p := &testPreset{testImage + ":latest"}
-	container, err := gnomock.Start(p, gnomock.WithTag("bad"))
-
-	defer func() {
-		require.NoError(t, gnomock.Stop(container))
-	}()
-
-	require.Error(t, err)
-}
-
 type testPreset struct {
 	image string
 }

--- a/sdktest/python/requirements.txt
+++ b/sdktest/python/requirements.txt
@@ -2,7 +2,7 @@ apipkg==1.5
 attrs==19.3.0
 certifi==2020.4.5.1
 execnet==1.7.1
-gnomock-python-sdk==1.1.2
+gnomock-python-sdk==1.2.0
 importlib-metadata==1.6.0
 more-itertools==8.2.0
 packaging==20.3

--- a/sdktest/python/test/test_sdk.py
+++ b/sdktest/python/test/test_sdk.py
@@ -13,9 +13,9 @@ class TestSDK(unittest.TestCase):
         return super().tearDown()
 
     def test_mongo(self):
-        options = gnomock.Options(tag="3")
+        options = gnomock.Options()
         file_name = os.path.abspath("./test/testdata/mongo")
-        preset = gnomock.Mongo(data_path=file_name)
+        preset = gnomock.Mongo(data_path=file_name, version="3")
         mongo_request = gnomock.MongoRequest(options=options, preset=preset)
         id = ""
 
@@ -31,9 +31,9 @@ class TestSDK(unittest.TestCase):
 
 
     def test_mysql(self):
-        options = gnomock.Options(tag="8")
+        options = gnomock.Options()
         file_name = os.path.abspath("./test/testdata/mysql/schema.sql")
-        preset = gnomock.Mysql(queries_file=file_name)
+        preset = gnomock.Mysql(queries_file=file_name, version="8")
         mysql_request = gnomock.MysqlRequest(options=options, preset=preset)
         id = ""
 
@@ -49,9 +49,9 @@ class TestSDK(unittest.TestCase):
 
 
     def test_mssql(self):
-        options = gnomock.Options(tag="2019-latest")
+        options = gnomock.Options()
         file_name = os.path.abspath("./test/testdata/mssql/schema.sql")
-        preset = gnomock.Mssql(queries_file=file_name, license=True)
+        preset = gnomock.Mssql(queries_file=file_name, license=True, version="2019-latest")
         mssql_request = gnomock.MssqlRequest(options=options, preset=preset)
         id = ""
 
@@ -67,9 +67,9 @@ class TestSDK(unittest.TestCase):
 
 
     def test_postgres(self):
-        options = gnomock.Options(tag="12")
+        options = gnomock.Options()
         file_name = os.path.abspath("./test/testdata/postgres/schema.sql")
-        preset = gnomock.Postgres(queries_file=file_name)
+        preset = gnomock.Postgres(queries_file=file_name, version="12")
         postgres_request = gnomock.PostgresRequest(options=options, preset=preset)
         id = ""
 
@@ -85,8 +85,8 @@ class TestSDK(unittest.TestCase):
 
 
     def test_redis(self):
-        options = gnomock.Options(tag="5")
-        preset = gnomock.Redis()
+        options = gnomock.Options()
+        preset = gnomock.Redis(version="5")
         redis_request = gnomock.RedisRequest(options=options, preset=preset)
         id = ""
 
@@ -102,10 +102,10 @@ class TestSDK(unittest.TestCase):
 
 
     def test_splunk(self):
-        options = gnomock.Options(tag="8.0.2.1")
+        options = gnomock.Options()
         file_name = os.path.abspath("./test/testdata/splunk/events.jsonl")
         preset = gnomock.Splunk(values_file=file_name, accept_license=True,
-                admin_password="12345678")
+                admin_password="12345678", version="8.0.2.1")
         splunk_request = gnomock.SplunkRequest(options=options, preset=preset)
         id = ""
 
@@ -121,8 +121,8 @@ class TestSDK(unittest.TestCase):
 
 
     def test_localstack(self):
-        options = gnomock.Options(tag="0.11.0")
-        preset = gnomock.Localstack(services=['s3'])
+        options = gnomock.Options()
+        preset = gnomock.Localstack(services=['s3'], version="0.11.0")
         localstack_request = gnomock.LocalstackRequest(options=options, preset=preset)
         id = ""
 

--- a/swagger/config/python.yaml
+++ b/swagger/config/python.yaml
@@ -1,4 +1,4 @@
 projectName: gnomock-python-sdk
 projectUrl: https://github.com/orlangure/gnomock
 packageName: gnomock
-packageVersion: 1.1.2
+packageVersion: 1.2.0

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -7,7 +7,7 @@ info:
     testing toolkit. It allows to use Gnomock outside of Go ecosystem. Not all
     Gnomock features exist in this wrapper, but official presets, as well as
     basic general configuration, are supported.
-  version: 1.1.1
+  version: 1.2.0
   contact:
     url: https://github.com/orlangure/gnomock/
   license:
@@ -272,10 +272,6 @@ components:
           items:
             type: string
             example: ENV_VAR_NAME=some-value
-        tag:
-          type: string
-          description: Docker image tag
-          example: latest
       description: >
         This object includes general Gnomock configuration, similar to all
         presets. Timeout configuration is especially useful for
@@ -334,6 +330,10 @@ components:
             Path to folder to setup initial S3 state. Top level folders are
             used as buckets; all child folders and files are uploaded as-is
           example: /home/gnomock/project/testdata/s3
+        version:
+          type: string
+          description: Docker image tag (version)
+          default: latest
       required:
         - services
       example:
@@ -370,6 +370,10 @@ components:
           type: string
           description: Password to set for the created user.
           example: p@s$w0rD
+        version:
+          type: string
+          description: Docker image tag (version)
+          default: latest
       description: >
         This object describes MongoDB container.
 
@@ -413,6 +417,10 @@ components:
           type: boolean
           description: Accept or decline Microsoft SQL Server license.
           example: true
+        version:
+          type: string
+          description: Docker image tag (version)
+          default: latest
       required:
         - license
       description: >
@@ -459,6 +467,10 @@ components:
           type: string
           description: A SQL file to execute while setting up container state.
           example: /home/gnomock/project/testdata/mysql/queries
+        version:
+          type: string
+          description: Docker image tag (version)
+          default: latest
       description: >
         This object describes MySQL container.
 
@@ -502,6 +514,10 @@ components:
           type: string
           description: A SQL file to execute while setting up container state.
           example: /home/gnomock/project/testdata/postgres/queries
+        version:
+          type: string
+          description: Docker image tag (version)
+          default: latest
       description: >
         This object describes Postgres container.
 
@@ -531,6 +547,10 @@ components:
             foo: bar
             baz: 42
             meh: 3.14
+        version:
+          type: string
+          description: Docker image tag (version)
+          default: latest
       description: >
         This object describes Redis container.
 
@@ -594,6 +614,7 @@ components:
         version:
           type: string
           description: Splunk version.
+          default: latest
           example: 8.0.2.1
       required:
         - accept_license


### PR DESCRIPTION
This is done since presets are likely to need their versions during
healthcheck or init functions.

Closes #17 