### PR TITLE
Return environment aware container address

### DIFF
--- a/container.go
+++ b/container.go
@@ -2,6 +2,7 @@ package gnomock
 
 import (
 	"fmt"
+	"os"
 )
 
 // Container represents a docker container created for testing. Host and Ports
@@ -20,7 +21,8 @@ type Container struct {
 	// and an actual port number as exposed on the host
 	Ports NamedPorts `json:"ports,omitempty"`
 
-	onStop func() error
+	gateway string
+	onStop  func() error
 }
 
 // Address is a convenience function that returns host:port that can be used to
@@ -46,4 +48,9 @@ func (c *Container) Port(name string) int {
 // DefaultPort returns Port() with DefaultPort
 func (c *Container) DefaultPort() int {
 	return c.Port(DefaultPort)
+}
+
+func isInDocker() bool {
+	_, err := os.Stat("/.dockerenv")
+	return err == nil
 }

--- a/server/main.go
+++ b/server/main.go
@@ -27,6 +27,6 @@ func main() {
 		os.Exit(0)
 	}
 
-	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	addr := fmt.Sprintf(":%d", port)
 	log.Println(http.ListenAndServe(addr, gnomockd.Handler()))
 }


### PR DESCRIPTION
This is a preparation for running gnomockd from inside a container. For
such future cases, gnomock won't be available to access new containers
through 127.0.0.1 address. Instead, it will need to use host IP address
as seen by the container (it is called Gateway).

Both cases need to be supported since gnomock can run both in a
container and directly on a host. So there is a different Host value
passed to heath and init functions (other usages are from the actual
code running on the host).