### PR TITLE
Implement RabbitMQ preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,16 +174,16 @@ are coming soon.
 The power of Gnomock is in the Presets. Presets, both existing and planned, are
 listed below:
 
-| Preset | Go package | HTTP API | Go API |
-|--------|------------|----------|--------|
-Localstack | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/localstack) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.4.0#/presets/startLocalstack) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/localstack?tab=doc)
-Splunk | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/splunk) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.4.0#/presets/startSplunk) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/splunk?tab=doc)
-Redis | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/redis) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.4.0#/presets/startRedis) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/redis?tab=doc)
-MySQL | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/mysql) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.4.0#/presets/startMysql) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/mysql?tab=doc)
-PostgreSQL | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/postgres) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.4.0#/presets/startPostgres) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/postgres?tab=doc)
-Microsoft SQL Server | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/mssql) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.4.0#/presets/startMssql) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/mssql?tab=doc)
-MongoDB | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/mongo) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.4.0#/presets/startMongo) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/mongo?tab=doc)
-RabbitMQ | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/rabbitmq) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.4.0#/presets/startRabbitMq) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/rabbitmq?tab=doc)
+| Preset | Go package | HTTP API | Go API | Latest stable image |
+|--------|------------|----------|--------|---------------------|
+Localstack | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/localstack) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.4.0#/presets/startLocalstack) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/localstack?tab=doc) | 0.11.0
+Splunk | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/splunk) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.4.0#/presets/startSplunk) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/splunk?tab=doc) | 8.0.2
+Redis | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/redis) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.4.0#/presets/startRedis) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/redis?tab=doc) | 5
+MySQL | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/mysql) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.4.0#/presets/startMysql) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/mysql?tab=doc) | 8
+PostgreSQL | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/postgres) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.4.0#/presets/startPostgres) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/postgres?tab=doc) | 12
+Microsoft SQL Server | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/mssql) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.4.0#/presets/startMssql) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/mssql?tab=doc) | 2019-latest
+MongoDB | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/mongo) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.4.0#/presets/startMongo) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/mongo?tab=doc) | 4
+RabbitMQ | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/rabbitmq) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.4.0#/presets/startRabbitMq) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/rabbitmq?tab=doc) | 3.8.5-alpine
 Elasticsearch | |
 DynamoDB | |
 Cassandra | |

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Zolotov](https://www.mzolotov.com/))
 ## Getting started
 
 Gnomock runs exposes an API over HTTP. This API is defined using OpenAPI 3.0
-[specification](https://app.swaggerhub.com/apis/orlangure/gnomock/1.3.0). Go
+[specification](https://app.swaggerhub.com/apis/orlangure/gnomock/1.4.0). Go
 programs can use an extended Gnomock package directly, without the HTTP layer,
 while other languages require communication with a Gnomock server.
 
@@ -176,13 +176,14 @@ listed below:
 
 | Preset | Go package | HTTP API | Go API |
 |--------|------------|----------|--------|
-Localstack | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/localstack) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.3.0#/presets/startLocalstack) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/localstack?tab=doc)
-Splunk | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/splunk) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.3.0#/presets/startSplunk) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/splunk?tab=doc)
-Redis | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/redis) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.3.0#/presets/startRedis) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/redis?tab=doc)
-MySQL | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/mysql) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.3.0#/presets/startMysql) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/mysql?tab=doc)
-PostgreSQL | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/postgres) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.3.0#/presets/startPostgres) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/postgres?tab=doc)
-Microsoft SQL Server | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/mssql) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.3.0#/presets/startMssql) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/mssql?tab=doc)
-MongoDB | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/mongo) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.3.0#/presets/startMongo) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/mongo?tab=doc)
+Localstack | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/localstack) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.4.0#/presets/startLocalstack) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/localstack?tab=doc)
+Splunk | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/splunk) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.4.0#/presets/startSplunk) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/splunk?tab=doc)
+Redis | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/redis) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.4.0#/presets/startRedis) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/redis?tab=doc)
+MySQL | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/mysql) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.4.0#/presets/startMysql) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/mysql?tab=doc)
+PostgreSQL | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/postgres) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.4.0#/presets/startPostgres) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/postgres?tab=doc)
+Microsoft SQL Server | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/mssql) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.4.0#/presets/startMssql) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/mssql?tab=doc)
+MongoDB | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/mongo) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.4.0#/presets/startMongo) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/mongo?tab=doc)
+RabbitMQ | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/rabbitmq) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.4.0#/presets/startRabbitMq) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/rabbitmq?tab=doc)
 Elasticsearch | |
 DynamoDB | |
 Cassandra | |

--- a/gnomockd/rabbitmq_test.go
+++ b/gnomockd/rabbitmq_test.go
@@ -1,0 +1,97 @@
+// +build !noserver
+
+package gnomockd_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/orlangure/gnomock"
+	"github.com/orlangure/gnomock/gnomockd"
+	"github.com/streadway/amqp"
+	"github.com/stretchr/testify/require"
+)
+
+// nolint:funlen,bodyclose
+func TestRabbitMQ(t *testing.T) {
+	t.Parallel()
+
+	h := gnomockd.Handler()
+	bs, err := ioutil.ReadFile("./testdata/rabbitmq.json")
+	require.NoError(t, err)
+
+	buf := bytes.NewBuffer(bs)
+	w, r := httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/start/rabbitmq", buf)
+	h.ServeHTTP(w, r)
+
+	res := w.Result()
+
+	defer func() { require.NoError(t, res.Body.Close()) }()
+
+	body, err := ioutil.ReadAll(res.Body)
+	require.NoError(t, err)
+
+	require.Equalf(t, http.StatusOK, res.StatusCode, string(body))
+
+	var c *gnomock.Container
+
+	err = json.Unmarshal(body, &c)
+	require.NoError(t, err)
+
+	uri := fmt.Sprintf(
+		"amqp://%s:%s@%s",
+		"guest", "guest",
+		c.DefaultAddress(),
+	)
+	conn, err := amqp.Dial(uri)
+	require.NoError(t, err)
+
+	defer func() { require.NoError(t, conn.Close()) }()
+
+	ch, err := conn.Channel()
+	require.NoError(t, err)
+
+	defer func() { require.NoError(t, ch.Close()) }()
+
+	q, err := ch.QueueDeclare(
+		"gnomock",
+		false, // Durable
+		false, // Delete when unused
+		false, // Exclusive
+		false, // No-wait
+		nil,   // Arguments
+	)
+	require.NoError(t, err)
+
+	msgBody := []byte("hello from Gnomock!")
+	err = ch.Publish(
+		"",     // exchange
+		q.Name, // routing key
+		false,  // mandatory
+		false,  // immediate
+		amqp.Publishing{
+			ContentType: "text/plain",
+			Body:        msgBody,
+		},
+	)
+	require.NoError(t, err)
+
+	msgs, err := ch.Consume(
+		q.Name, // queue
+		"",     // consumer
+		true,   // auto-ack
+		false,  // exclusive
+		false,  // no-local
+		false,  // no-wait
+		nil,    // args
+	)
+	require.NoError(t, err)
+
+	m := <-msgs
+	require.Equal(t, msgBody, m.Body)
+}

--- a/gnomockd/testdata/mongo.json
+++ b/gnomockd/testdata/mongo.json
@@ -3,7 +3,7 @@
         "data_path": "./testdata/mongo",
         "user": "gnomock",
         "password": "foobar",
-        "version": "3"
+        "version": "4"
     },
     "options": {}
 }

--- a/gnomockd/testdata/rabbitmq.json
+++ b/gnomockd/testdata/rabbitmq.json
@@ -1,0 +1,8 @@
+{
+    "preset": {
+        "version": "3.8.5-alpine"
+    },
+    "options": {
+        "debug": true
+    }
+}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/gorilla/mux v1.7.4
 	github.com/lib/pq v1.5.1
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
+	github.com/streadway/amqp v1.0.0
 	github.com/stretchr/testify v1.5.1
 	go.mongodb.org/mongo-driver v1.3.2
 	go.uber.org/zap v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -111,6 +111,8 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/streadway/amqp v1.0.0 h1:kuuDrUJFZL1QYL9hUNuCxNObNzB0bV/ZG5jV3RWAQgo=
+github.com/streadway/amqp v1.0.0/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/preset/localstack/preset_test.go
+++ b/preset/localstack/preset_test.go
@@ -22,7 +22,10 @@ import (
 func TestPreset_s3(t *testing.T) {
 	t.Parallel()
 
-	p := localstack.Preset(localstack.WithServices(localstack.S3))
+	p := localstack.Preset(
+		localstack.WithServices(localstack.S3),
+		localstack.WithVersion("0.11.0"),
+	)
 	c, err := gnomock.Start(p)
 
 	defer func() { require.NoError(t, gnomock.Stop(c)) }()
@@ -72,6 +75,7 @@ func TestPreset_sqs_sns(t *testing.T) {
 
 	p := localstack.Preset(
 		localstack.WithServices(localstack.SNS, localstack.SQS),
+		localstack.WithVersion("0.11.0"),
 	)
 	c, err := gnomock.Start(p)
 

--- a/preset/localstack/s3_test.go
+++ b/preset/localstack/s3_test.go
@@ -22,6 +22,7 @@ func TestWithS3Files(t *testing.T) {
 	p := localstack.Preset(
 		localstack.WithServices(localstack.S3),
 		localstack.WithS3Files("testdata/s3"),
+		localstack.WithVersion("0.11.0"),
 	)
 	c, err := gnomock.Start(p)
 

--- a/preset/rabbitmq/options.go
+++ b/preset/rabbitmq/options.go
@@ -1,0 +1,21 @@
+package rabbitmq
+
+// Option is an optional configuration of this Gnomock preset. Use available
+// Options to configure the container
+type Option func(*P)
+
+// WithUser creates a new superuser with the provided credentials in the
+// container
+func WithUser(user, password string) Option {
+	return func(p *P) {
+		p.User = user
+		p.Password = password
+	}
+}
+
+// WithVersion sets image version.
+func WithVersion(version string) Option {
+	return func(o *P) {
+		o.Version = version
+	}
+}

--- a/preset/rabbitmq/preset.go
+++ b/preset/rabbitmq/preset.go
@@ -1,0 +1,90 @@
+// Package rabbitmq provides a Gnomock Preset for RabbitMQ
+package rabbitmq
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/orlangure/gnomock"
+	"github.com/streadway/amqp"
+)
+
+const defaultUser = "guest"
+const defaultPassword = "guest"
+const defaultVersion = "alpine"
+const defaultPort = 5672
+
+// Preset creates a new Gmomock RabbitMQ preset. This preset includes a RabbitMQ
+// specific healthcheck function and default RabbitMQ image and port.
+func Preset(opts ...Option) gnomock.Preset {
+	p := &P{}
+
+	for _, opt := range opts {
+		opt(p)
+	}
+
+	return p
+}
+
+// P is a Gnomock Preset implementation of RabbitMQ.
+type P struct {
+	User     string `json:"user"`
+	Password string `json:"password"`
+	Version  string `json:"version"`
+}
+
+// Image returns an image that should be pulled to create this container
+func (p *P) Image() string {
+	return fmt.Sprintf("docker.io/library/rabbitmq:%s", p.Version)
+}
+
+// Ports returns ports that should be used to access this container
+func (p *P) Ports() gnomock.NamedPorts {
+	return gnomock.DefaultTCP(defaultPort)
+}
+
+// Options returns a list of options to configure this container
+func (p *P) Options() []gnomock.Option {
+	p.setDefaults()
+
+	opts := []gnomock.Option{
+		gnomock.WithHealthCheck(p.healthcheck),
+	}
+
+	if p.User != "" && p.Password != "" {
+		opts = append(
+			opts,
+			gnomock.WithEnv("RABBITMQ_DEFAULT_USER="+p.User),
+			gnomock.WithEnv("RABBITMQ_DEFAULT_PASS="+p.Password),
+		)
+	}
+
+	return opts
+}
+
+func (p *P) healthcheck(ctx context.Context, c *gnomock.Container) error {
+	uri := fmt.Sprintf("amqp://%s:%s@%s:%d", p.User, p.Password, c.Host, c.DefaultPort())
+
+	conn, err := amqp.Dial(uri)
+	if err != nil {
+		return fmt.Errorf("connection failed: %w", err)
+	}
+
+	err = conn.Close()
+	if err != nil {
+		return fmt.Errorf("can't close connection: %w", err)
+	}
+
+	return nil
+}
+
+func (p *P) setDefaults() {
+	if p.Version == "" {
+		p.Version = defaultVersion
+	}
+
+	if p.User == "" && p.Password == "" {
+		p.User = defaultUser
+		p.Password = defaultPassword
+	}
+}

--- a/preset/rabbitmq/preset_test.go
+++ b/preset/rabbitmq/preset_test.go
@@ -1,0 +1,81 @@
+// +build !nopreset
+
+package rabbitmq_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/orlangure/gnomock"
+	"github.com/orlangure/gnomock/preset/rabbitmq"
+	"github.com/streadway/amqp"
+	"github.com/stretchr/testify/require"
+)
+
+// nolint:funlen
+func TestPreset(t *testing.T) {
+	t.Parallel()
+
+	// gnomock setup
+	p := rabbitmq.Preset(
+		rabbitmq.WithUser("gnomock", "strong-password"),
+	)
+
+	container, err := gnomock.Start(p)
+	require.NoError(t, err)
+
+	defer func() { require.NoError(t, gnomock.Stop(container)) }()
+
+	// actual test code
+	uri := fmt.Sprintf(
+		"amqp://%s:%s@%s",
+		"gnomock", "strong-password",
+		container.DefaultAddress(),
+	)
+	conn, err := amqp.Dial(uri)
+	require.NoError(t, err)
+
+	defer func() { require.NoError(t, conn.Close()) }()
+
+	ch, err := conn.Channel()
+	require.NoError(t, err)
+
+	defer func() { require.NoError(t, ch.Close()) }()
+
+	q, err := ch.QueueDeclare(
+		"gnomock",
+		false, // Durable
+		false, // Delete when unused
+		false, // Exclusive
+		false, // No-wait
+		nil,   // Arguments
+	)
+	require.NoError(t, err)
+
+	msgBody := []byte("hello from Gnomock!")
+	err = ch.Publish(
+		"",     // exchange
+		q.Name, // routing key
+		false,  // mandatory
+		false,  // immediate
+		amqp.Publishing{
+			ContentType: "text/plain",
+			Body:        msgBody,
+		},
+	)
+	require.NoError(t, err)
+
+	msgs, err := ch.Consume(
+		q.Name, // queue
+		"",     // consumer
+		true,   // auto-ack
+		false,  // exclusive
+		false,  // no-local
+		false,  // no-wait
+		nil,    // args
+	)
+	require.NoError(t, err)
+
+	m := <-msgs
+	require.Equal(t, msgBody, m.Body)
+}

--- a/preset/rabbitmq/readme.md
+++ b/preset/rabbitmq/readme.md
@@ -1,0 +1,82 @@
+# Gnomock RabbitMQ
+
+Gnomock RabbitMQ is a [Gnomock](https://github.com/orlangure/gnomock) preset for
+running tests against a real RabbitMQ message queue, without mocks.
+
+```go
+package rabbitmq_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/orlangure/gnomock"
+	"github.com/orlangure/gnomock/preset/rabbitmq"
+	"github.com/streadway/amqp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPreset(t *testing.T) {
+	t.Parallel()
+
+	// gnomock setup
+	p := rabbitmq.Preset(
+		rabbitmq.WithUser("gnomock", "strong-password"),
+	)
+
+	container, err := gnomock.Start(p)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, gnomock.Stop(container)) }()
+
+	// actual test code
+	uri := fmt.Sprintf(
+		"amqp://%s:%s@%s",
+		"gnomock", "strong-password",
+		container.DefaultAddress(),
+	)
+	conn, err := amqp.Dial(uri)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, conn.Close()) }()
+
+	ch, err := conn.Channel()
+	require.NoError(t, err)
+	defer func() { require.NoError(t, ch.Close()) }()
+
+	q, err := ch.QueueDeclare(
+		"gnomock",
+		false, // Durable
+		false, // Delete when unused
+		false, // Exclusive
+		false, // No-wait
+		nil,   // Arguments
+	)
+	require.NoError(t, err)
+
+	msgBody := []byte("hello from Gnomock!")
+	err = ch.Publish(
+		"",     // exchange
+		q.Name, // routing key
+		false,  // mandatory
+		false,  // immediate
+		amqp.Publishing{
+			ContentType: "text/plain",
+			Body:        msgBody,
+		},
+	)
+	require.NoError(t, err)
+
+	msgs, err := ch.Consume(
+		q.Name, // queue
+		"",     // consumer
+		true,   // auto-ack
+		false,  // exclusive
+		false,  // no-local
+		false,  // no-wait
+		nil,    // args
+	)
+	require.NoError(t, err)
+
+	m := <-msgs
+	require.Equal(t, msgBody, m.Body)
+}
+```

--- a/preset/registry.go
+++ b/preset/registry.go
@@ -8,6 +8,7 @@ import (
 	"github.com/orlangure/gnomock/preset/mssql"
 	"github.com/orlangure/gnomock/preset/mysql"
 	"github.com/orlangure/gnomock/preset/postgres"
+	"github.com/orlangure/gnomock/preset/rabbitmq"
 	"github.com/orlangure/gnomock/preset/redis"
 	"github.com/orlangure/gnomock/preset/splunk"
 )
@@ -35,6 +36,8 @@ func (r registry) Preset(name string) gnomock.Preset {
 		return &redis.P{}
 	case "splunk":
 		return &splunk.P{}
+	case "rabbitmq":
+		return &rabbitmq.P{}
 	}
 
 	return nil

--- a/sdktest/python/requirements.txt
+++ b/sdktest/python/requirements.txt
@@ -2,7 +2,7 @@ apipkg==1.5
 attrs==19.3.0
 certifi==2020.4.5.1
 execnet==1.7.1
-gnomock-python-sdk==1.3.0
+gnomock-python-sdk==1.4.0
 importlib-metadata==1.6.0
 more-itertools==8.2.0
 packaging==20.3

--- a/sdktest/python/test/test_sdk.py
+++ b/sdktest/python/test/test_sdk.py
@@ -136,6 +136,23 @@ class TestSDK(unittest.TestCase):
                 stop_request = gnomock.StopRequest(id=id)
                 self.api.stop(stop_request)
 
+    def test_rabbitmq(self):
+        options = gnomock.Options()
+        preset = gnomock.Rabbitmq(version="3.8.5-alpine")
+        rabbitmq_request = gnomock.RabbitmqRequest(options=options,
+                preset=preset)
+        id = ""
+
+        try:
+            response = self.api.start_rabbit_mq(rabbitmq_request)
+            id = response.id
+            self.assertEqual("127.0.0.1", response.host)
+
+        finally:
+            if id is not "":
+                stop_request = gnomock.StopRequest(id=id)
+                self.api.stop(stop_request)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/swagger/config/python.yaml
+++ b/swagger/config/python.yaml
@@ -1,4 +1,4 @@
 projectName: gnomock-python-sdk
 projectUrl: https://github.com/orlangure/gnomock
 packageName: gnomock
-packageVersion: 1.3.0
+packageVersion: 1.4.0

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -7,7 +7,7 @@ info:
     testing toolkit. It allows to use Gnomock outside of Go ecosystem. Not all
     Gnomock features exist in this wrapper, but official presets, as well as
     basic general configuration, are supported.
-  version: 1.3.0
+  version: 1.4.0
   contact:
     url: https://github.com/orlangure/gnomock/
   license:
@@ -142,6 +142,25 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/splunk-request'
+      responses:
+        '200':
+          $ref: '#/components/responses/container-created'
+        '400':
+          $ref: '#/components/responses/invalid-configuration'
+        '500':
+          $ref: '#/components/responses/start-failed'
+      tags:
+        - presets
+  /start/rabbitmq:
+    post:
+      summary: Start a new Gnomock RabbitMQ container
+      operationId: startRabbitMq
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/rabbitmq-request'
       responses:
         '200':
           $ref: '#/components/responses/container-created'
@@ -634,6 +653,37 @@ components:
         - admin_password
       description: >
         This object describes Splunk container.
+
+    rabbitmq-request:
+      type: object
+      properties:
+        preset:
+          $ref: '#/components/schemas/rabbitmq'
+        options:
+          $ref: '#/components/schemas/options'
+      description: >
+        This request includes RabbitMQ and general configuration.
+
+    rabbitmq:
+      type: object
+      properties:
+        user:
+          type: string
+          description: Set a user name
+          example: gnomock
+          default: guest
+        password:
+          type: string
+          description: Set a password for a created user
+          example: p@s$w0rD
+          default: guest
+        version:
+          type: string
+          description: RabbitMQ version.
+          default: 3.8.5-alpine
+          example: latest
+      description: >
+        This object describes a RabbitMQ container.
 
     stop-request:
       type: object


### PR DESCRIPTION
This PR adds a new preset - RabbitMQ.

With it comes an update to [Gnomock Swagger API](https://app.swaggerhub.com/apis/orlangure/gnomock/1.4.0) and [Python SDK](https://github.com/orlangure/gnomock-python-sdk).