### PR TITLE
Implement RabbitMQ messages import

### DIFF
--- a/preset/rabbitmq/options.go
+++ b/preset/rabbitmq/options.go
@@ -22,3 +22,27 @@ func WithVersion(version string) Option {
 		o.Version = version
 	}
 }
+
+// WithQueues makes sure that the provided queues are available when RabbitMQ is up and
+// running.
+func WithQueues(queues ...string) Option {
+	return func(p *P) {
+		p.Queues = append(p.Queues, queues...)
+	}
+}
+
+// WithMessages makes sure that these messages can be consumed during the test once the
+// container is ready.
+func WithMessages(messages ...Message) Option {
+	return func(p *P) {
+		p.Messages = append(p.Messages, messages...)
+	}
+}
+
+// WithMessagesFile allows to load messages to be sent into RabbitMQ from one or multible
+// files.
+func WithMessagesFile(file string) Option {
+	return func(p *P) {
+		p.MessagesFiles = append(p.MessagesFiles, file)
+	}
+}

--- a/preset/rabbitmq/options.go
+++ b/preset/rabbitmq/options.go
@@ -23,14 +23,6 @@ func WithVersion(version string) Option {
 	}
 }
 
-// WithQueues makes sure that the provided queues are available when RabbitMQ is up and
-// running.
-func WithQueues(queues ...string) Option {
-	return func(p *P) {
-		p.Queues = append(p.Queues, queues...)
-	}
-}
-
 // WithMessages makes sure that these messages can be consumed during the test once the
 // container is ready.
 func WithMessages(messages ...Message) Option {

--- a/preset/rabbitmq/preset.go
+++ b/preset/rabbitmq/preset.go
@@ -29,8 +29,8 @@ const managementPort = 15672
 // Message is a single message sent to RabbitMQ.
 type Message struct {
 	Queue       string `json:"queue"`
-	ContentType string `json:"contentType"`
-	StringBody  string `json:"stringBody"`
+	ContentType string `json:"content_type"`
+	StringBody  string `json:"string_body"`
 	Body        []byte `json:"body"`
 }
 
@@ -137,32 +137,6 @@ func (p *P) setDefaults() {
 	}
 }
 
-func (p *P) loadFiles() error {
-	if len(p.MessagesFiles) > 0 {
-		for _, fName := range p.MessagesFiles {
-			msgs, err := p.loadMessagesFromFile(fName)
-			if err != nil {
-				return fmt.Errorf("can't read messages from file '%s': %w", fName, err)
-			}
-
-			p.Messages = append(p.Messages, msgs...)
-		}
-	}
-
-	return nil
-}
-
-func declareQueues(ch *amqp.Channel, qs []string) error {
-	for _, queue := range qs {
-		_, err := ch.QueueDeclare(queue, false, false, false, false, nil)
-		if err != nil {
-			return fmt.Errorf("can't open queue '%s': %w", queue, err)
-		}
-	}
-
-	return nil
-}
-
 func (p *P) initf(ctx context.Context, c *gnomock.Container) (err error) {
 	conn, err := p.connect(c)
 	if err != nil {
@@ -209,6 +183,32 @@ func (p *P) initf(ctx context.Context, c *gnomock.Container) (err error) {
 	for queue, messages := range messagesByQueue {
 		if err := p.sendMessagesIntoQueue(ch, queue, messages); err != nil {
 			return fmt.Errorf("can't send messages into queue '%s': %w", queue, err)
+		}
+	}
+
+	return nil
+}
+
+func (p *P) loadFiles() error {
+	if len(p.MessagesFiles) > 0 {
+		for _, fName := range p.MessagesFiles {
+			msgs, err := p.loadMessagesFromFile(fName)
+			if err != nil {
+				return fmt.Errorf("can't read messages from file '%s': %w", fName, err)
+			}
+
+			p.Messages = append(p.Messages, msgs...)
+		}
+	}
+
+	return nil
+}
+
+func declareQueues(ch *amqp.Channel, qs []string) error {
+	for _, queue := range qs {
+		_, err := ch.QueueDeclare(queue, false, false, false, false, nil)
+		if err != nil {
+			return fmt.Errorf("can't open queue '%s': %w", queue, err)
 		}
 	}
 

--- a/preset/rabbitmq/preset_test.go
+++ b/preset/rabbitmq/preset_test.go
@@ -113,20 +113,33 @@ func TestPreset_withMessages(t *testing.T) {
 		{
 			Queue:       "events",
 			ContentType: "text/plain",
-			Body:        "order: 1",
+			StringBody:  "order: 1",
 		},
 		{
 			Queue:       "alerts",
 			ContentType: "text/plain",
-			Body:        "CPU: 92",
+			StringBody:  "CPU: 92",
+		},
+	}
+
+	byteMessages := []rabbitmq.Message{
+		{
+			Queue:       "events",
+			ContentType: "text/binary", // non-existent format for test
+			Body:        []byte{54, 23, 12, 76, 54},
+		},
+		{
+			Queue:       "alerts",
+			ContentType: "text/binary", // non-existent format for test
+			Body:        []byte{75, 12, 8, 42, 12},
 		},
 	}
 
 	// gnomock setup
 	p := rabbitmq.Preset(
 		rabbitmq.WithUser("gnomock", "strong-password"),
-		rabbitmq.WithQueues("topic-1", "topic-2"),
 		rabbitmq.WithMessages(messages...),
+		rabbitmq.WithMessages(byteMessages...),
 	)
 
 	container, err := gnomock.Start(p)
@@ -155,12 +168,20 @@ func TestPreset_withMessages(t *testing.T) {
 
 	m, ok := <-msgs
 	require.Equal(t, true, ok)
-	require.Equal(t, []byte(messages[0].Body), m.Body)
+	require.Equal(t, []byte(messages[0].StringBody), m.Body)
+
+	m, ok = <-msgs
+	require.Equal(t, true, ok)
+	require.Equal(t, byteMessages[0].Body, m.Body)
 
 	msgs, err = ch.Consume("alerts", "", true, false, false, false, nil)
 	require.NoError(t, err)
 
 	m, ok = <-msgs
 	require.Equal(t, true, ok)
-	require.Equal(t, []byte(messages[1].Body), m.Body)
+	require.Equal(t, []byte(messages[1].StringBody), m.Body)
+
+	m, ok = <-msgs
+	require.Equal(t, true, ok)
+	require.Equal(t, byteMessages[1].Body, m.Body)
 }

--- a/preset/rabbitmq/preset_test.go
+++ b/preset/rabbitmq/preset_test.go
@@ -17,9 +17,37 @@ import (
 func TestPreset(t *testing.T) {
 	t.Parallel()
 
+	messages := []rabbitmq.Message{
+		{
+			Queue:       "events",
+			ContentType: "text/plain",
+			StringBody:  "order: 1",
+		},
+		{
+			Queue:       "alerts",
+			ContentType: "text/plain",
+			StringBody:  "CPU: 92",
+		},
+	}
+
+	byteMessages := []rabbitmq.Message{
+		{
+			Queue:       "events",
+			ContentType: "text/binary", // non-existent format for test
+			Body:        []byte{54, 23, 12, 76, 54},
+		},
+		{
+			Queue:       "alerts",
+			ContentType: "text/binary", // non-existent format for test
+			Body:        []byte{75, 12, 8, 42, 12},
+		},
+	}
+
 	// gnomock setup
 	p := rabbitmq.Preset(
 		rabbitmq.WithUser("gnomock", "strong-password"),
+		rabbitmq.WithMessages(messages...),
+		rabbitmq.WithMessages(byteMessages...),
 	)
 
 	container, err := gnomock.Start(p)
@@ -79,6 +107,31 @@ func TestPreset(t *testing.T) {
 
 	m := <-msgs
 	require.Equal(t, msgBody, m.Body)
+
+	// ===================================
+	// Test for string and binary messages
+	// ===================================
+	msgs, err = ch.Consume("events", "", true, false, false, false, nil)
+	require.NoError(t, err)
+
+	m, ok := <-msgs
+	require.Equal(t, true, ok)
+	require.Equal(t, []byte(messages[0].StringBody), m.Body)
+
+	m, ok = <-msgs
+	require.Equal(t, true, ok)
+	require.Equal(t, byteMessages[0].Body, m.Body)
+
+	msgs, err = ch.Consume("alerts", "", true, false, false, false, nil)
+	require.NoError(t, err)
+
+	m, ok = <-msgs
+	require.Equal(t, true, ok)
+	require.Equal(t, []byte(messages[1].StringBody), m.Body)
+
+	m, ok = <-msgs
+	require.Equal(t, true, ok)
+	require.Equal(t, byteMessages[1].Body, m.Body)
 }
 
 func TestPreset_withManagement(t *testing.T) {
@@ -104,120 +157,4 @@ func TestPreset_withManagement(t *testing.T) {
 	defer require.NoError(t, resp.Body.Close())
 
 	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
-}
-
-func TestPreset_withMessages(t *testing.T) {
-	t.Parallel()
-
-	messages := []rabbitmq.Message{
-		{
-			Queue:       "events",
-			ContentType: "text/plain",
-			StringBody:  "order: 1",
-		},
-		{
-			Queue:       "alerts",
-			ContentType: "text/plain",
-			StringBody:  "CPU: 92",
-		},
-	}
-
-	// gnomock setup
-	p := rabbitmq.Preset(
-		rabbitmq.WithUser("gnomock", "strong-password"),
-		rabbitmq.WithMessages(messages...),
-	)
-
-	container, err := gnomock.Start(p)
-	require.NoError(t, err)
-
-	defer func() { require.NoError(t, gnomock.Stop(container)) }()
-
-	// actual test code
-	uri := fmt.Sprintf(
-		"amqp://%s:%s@%s",
-		"gnomock", "strong-password",
-		container.DefaultAddress(),
-	)
-	conn, err := amqp.Dial(uri)
-	require.NoError(t, err)
-
-	defer func() { require.NoError(t, conn.Close()) }()
-
-	ch, err := conn.Channel()
-	require.NoError(t, err)
-
-	defer func() { require.NoError(t, ch.Close()) }()
-
-	msgs, err := ch.Consume("events", "", true, false, false, false, nil)
-	require.NoError(t, err)
-
-	m, ok := <-msgs
-	require.Equal(t, true, ok)
-	require.Equal(t, []byte(messages[0].StringBody), m.Body)
-
-	msgs, err = ch.Consume("alerts", "", true, false, false, false, nil)
-	require.NoError(t, err)
-
-	m, ok = <-msgs
-	require.Equal(t, true, ok)
-	require.Equal(t, []byte(messages[1].StringBody), m.Body)
-}
-
-func TestPreset_withBinaryMessages(t *testing.T) {
-	t.Parallel()
-
-	byteMessages := []rabbitmq.Message{
-		{
-			Queue:       "events",
-			ContentType: "text/binary", // non-existent format for test
-			Body:        []byte{54, 23, 12, 76, 54},
-		},
-		{
-			Queue:       "alerts",
-			ContentType: "text/binary", // non-existent format for test
-			Body:        []byte{75, 12, 8, 42, 12},
-		},
-	}
-
-	// gnomock setup
-	p := rabbitmq.Preset(
-		rabbitmq.WithUser("gnomock", "strong-password"),
-		rabbitmq.WithMessages(byteMessages...),
-	)
-
-	container, err := gnomock.Start(p)
-	require.NoError(t, err)
-
-	defer func() { require.NoError(t, gnomock.Stop(container)) }()
-
-	// actual test code
-	uri := fmt.Sprintf(
-		"amqp://%s:%s@%s",
-		"gnomock", "strong-password",
-		container.DefaultAddress(),
-	)
-	conn, err := amqp.Dial(uri)
-	require.NoError(t, err)
-
-	defer func() { require.NoError(t, conn.Close()) }()
-
-	ch, err := conn.Channel()
-	require.NoError(t, err)
-
-	defer func() { require.NoError(t, ch.Close()) }()
-
-	msgs, err := ch.Consume("events", "", true, false, false, false, nil)
-	require.NoError(t, err)
-
-	m, ok := <-msgs
-	require.Equal(t, true, ok)
-	require.Equal(t, byteMessages[0].Body, m.Body)
-
-	msgs, err = ch.Consume("alerts", "", true, false, false, false, nil)
-	require.NoError(t, err)
-
-	m, ok = <-msgs
-	require.Equal(t, true, ok)
-	require.Equal(t, byteMessages[1].Body, m.Body)
 }


### PR DESCRIPTION
This implements the requested feature. Also able to add queues however they would've been automatically created event if they don't exist once `QueueDeclare()` is called so that feature is not really necessary. I'd like your thoughts on this.

Also I see that AMQP library sends bite slices as data and user can specify the content type. This means that user could also send binary data to RabbitMQ. We could implement something like that, similar to the feature in Memcached preset (`WithValues` and `WithByteValues`).

Closes: https://github.com/orlangure/gnomock/issues/59