### PR TITLE
Add minimal circleci configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,31 @@
+version: 2
+jobs:
+  lint:
+    docker:
+      - image: circleci/golang:1.15
+    steps:
+      - checkout
+      - run:
+          name: golangci-lint
+          command: |
+            curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.23.8
+            $(go env GOPATH)/bin/golangci-lint run ./...
+  test:
+    machine: true
+    steps:
+      - checkout
+      - run:
+          name: install golang
+          command: |
+            sudo rm -rf /usr/local/go
+            wget -c https://dl.google.com/go/go1.15.3.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
+      - run:
+          name: test
+          command: GOMAXPROCS=2 go test -v -race -cover .
+
+workflows:
+  version: 2
+  build-workflow:
+    jobs:
+      - lint
+      - test

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,5 @@ RUN CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -a -installsuffix cgo -ldflag
 FROM scratch
 
 COPY --from=builder /gnomockd /gnomockd
+ENV GNOMOCK_ENV=gnomockd
 ENTRYPOINT ["/gnomockd"]

--- a/container.go
+++ b/container.go
@@ -51,6 +51,6 @@ func (c *Container) DefaultPort() int {
 }
 
 func isInDocker() bool {
-	_, err := os.Stat("/.dockerenv")
-	return err == nil
+	env := os.Getenv("GNOMOCK_ENV")
+	return env == "gnomockd"
 }


### PR DESCRIPTION
This PR adds minimal configuration to run builds in CircleCI.

I believe many users use it as their CI platform, and up to this point I only tried using Gnomock in Github Actions.
As it turns out, CircleCI is a bit different since every test there can be executed in docker, and it breaks things.

One of the changes fixes how we determine whether gnomock runs in its own container (when not used by Go). Instead of looking at `.dockerenv` file, we just test a pre-defined environment variable set at build time.

The other change fixes rabbitmq containers that were not stopped after tests.