### PR TITLE
Configure golangci-lint to skip some linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,3 +37,11 @@ linters:
     - unparam
     - whitespace
     - wsl
+
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - funlen
+        - bodyclose
+        - gosec

--- a/gnomock_test.go
+++ b/gnomock_test.go
@@ -1,4 +1,3 @@
-//nolint:gosec
 package gnomock_test
 
 import (

--- a/internal/gnomockd/elastic_test.go
+++ b/internal/gnomockd/elastic_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// nolint:bodyclose,funlen
 func TestElastic(t *testing.T) {
 	if israce.Enabled {
 		t.Skip("elastic tests can't run with race detector due to https://github.com/elastic/go-elasticsearch/issues/147")

--- a/internal/gnomockd/gnomockd_test.go
+++ b/internal/gnomockd/gnomockd_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//nolint:bodyclose
 func TestGnomockd(t *testing.T) {
 	t.Run("start with preset not found", func(t *testing.T) {
 		t.Parallel()

--- a/internal/gnomockd/kafka_test.go
+++ b/internal/gnomockd/kafka_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// nolint:bodyclose,funlen
 func TestKafka(t *testing.T) {
 	t.Parallel()
 

--- a/internal/gnomockd/localstack_test.go
+++ b/internal/gnomockd/localstack_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//nolint:bodyclose
 func TestLocalstack(t *testing.T) {
 	t.Parallel()
 

--- a/internal/gnomockd/mariadb_test.go
+++ b/internal/gnomockd/mariadb_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//nolint:bodyclose
 func TestMariaDB(t *testing.T) {
 	t.Parallel()
 

--- a/internal/gnomockd/memcached_test.go
+++ b/internal/gnomockd/memcached_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//nolint:bodyclose
 func TestMemcached(t *testing.T) {
 	t.Parallel()
 

--- a/internal/gnomockd/mongo_test.go
+++ b/internal/gnomockd/mongo_test.go
@@ -18,7 +18,6 @@ import (
 	mongooptions "go.mongodb.org/mongo-driver/mongo/options"
 )
 
-//nolint:bodyclose
 func TestMongo(t *testing.T) {
 	t.Parallel()
 

--- a/internal/gnomockd/mssql_test.go
+++ b/internal/gnomockd/mssql_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//nolint:bodyclose
 func TestMSSQL(t *testing.T) {
 	t.Parallel()
 

--- a/internal/gnomockd/mysql_test.go
+++ b/internal/gnomockd/mysql_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//nolint:bodyclose
 func TestMySQL(t *testing.T) {
 	t.Parallel()
 

--- a/internal/gnomockd/postgres_test.go
+++ b/internal/gnomockd/postgres_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//nolint:bodyclose
 func TestPostgres(t *testing.T) {
 	t.Parallel()
 

--- a/internal/gnomockd/rabbitmq_test.go
+++ b/internal/gnomockd/rabbitmq_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// nolint:funlen,bodyclose
 func TestRabbitMQ(t *testing.T) {
 	t.Parallel()
 

--- a/internal/gnomockd/redis_test.go
+++ b/internal/gnomockd/redis_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//nolint:bodyclose
 func TestRedis(t *testing.T) {
 	t.Parallel()
 

--- a/internal/gnomockd/splunk_test.go
+++ b/internal/gnomockd/splunk_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//nolint:funlen,bodyclose
 func TestSplunk(t *testing.T) {
 	t.Parallel()
 
@@ -45,7 +44,7 @@ func TestSplunk(t *testing.T) {
 
 	client := &http.Client{
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		},
 	}
 

--- a/preset/kafka/preset_test.go
+++ b/preset/kafka/preset_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// nolint:funlen
 func TestPreset(t *testing.T) {
 	t.Parallel()
 

--- a/preset/localstack/preset_internal_test.go
+++ b/preset/localstack/preset_internal_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// nolint:funlen
 func TestHealthCheckAddress(t *testing.T) {
 	legacyPath := "http://127.0.0.1:33333/health"
 	newPath := "http://127.0.0.1:44444/health"

--- a/preset/localstack/preset_test.go
+++ b/preset/localstack/preset_test.go
@@ -66,7 +66,6 @@ func TestPreset_s3(t *testing.T) {
 	require.Equal(t, 1, len(out.Contents))
 }
 
-//nolint:funlen
 func TestPreset_sqs_sns(t *testing.T) {
 	t.Parallel()
 

--- a/preset/localstack/s3_test.go
+++ b/preset/localstack/s3_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//nolint:funlen
 func TestWithS3Files(t *testing.T) {
 	// testdata/s3 includes 100 files in my-bucket/dir folder
 	p := localstack.Preset(

--- a/preset/rabbitmq/preset_test.go
+++ b/preset/rabbitmq/preset_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// nolint:funlen
 func TestPreset(t *testing.T) {
 	t.Parallel()
 
@@ -149,7 +148,7 @@ func TestPreset_withManagement(t *testing.T) {
 	addr := container.Address(rabbitmq.ManagementPort)
 	url := fmt.Sprintf("http://%s/api/overview", addr)
 
-	resp, err := http.Get(url) // nolint:gosec
+	resp, err := http.Get(url)
 	require.NoError(t, err)
 
 	defer require.NoError(t, resp.Body.Close())

--- a/preset/splunk/preset_test.go
+++ b/preset/splunk/preset_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//nolint:funlen
 func TestPreset(t *testing.T) {
 	events := make([]splunk.Event, 1000)
 
@@ -65,7 +64,7 @@ func TestPreset(t *testing.T) {
 	t.Run("initial values ingested", func(t *testing.T) {
 		client := &http.Client{
 			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 			},
 		}
 


### PR DESCRIPTION
Skip `funlen`, `bodyclose`, `gosec` in the test files.
Also, removed `//nolinter` annotations.

Fixes #72 