### PR TITLE
Test RabbitMQ init over HTTP

### DIFF
--- a/internal/gnomockd/testdata/rabbitmq.json
+++ b/internal/gnomockd/testdata/rabbitmq.json
@@ -1,6 +1,24 @@
 {
     "preset": {
-        "version": "3.8.5-alpine"
+        "version": "3.8.5-alpine",
+        "messages": [
+            {
+                "queue": "events",
+                "content_type": "text/plain",
+                "string_body": "something"
+            },
+            {
+                "queue": "alerts",
+                "content_type": "text/plain",
+                "string_body": "high cpu"
+            },
+            {
+                "queue": "events",
+                "content_type": "text/binary",
+                "body": "Zm9vYmFy"
+            }
+        ],
+        "messages_files": ["./testdata/rabbitmq/messages.jsonl"]
     },
     "options": {
         "debug": true

--- a/internal/gnomockd/testdata/rabbitmq/messages.jsonl
+++ b/internal/gnomockd/testdata/rabbitmq/messages.jsonl
@@ -1,0 +1,3 @@
+{ "queue": "events", "content_type": "text/plain", "string_body": "something else" }
+{ "queue": "alerts", "content_type": "text/plain", "string_body": "memory pressure" }
+{ "queue": "alerts", "content_type": "text/binary", "body": "Z25vbW9jaw==" }

--- a/sdktest/python/test/test_sdk.py
+++ b/sdktest/python/test/test_sdk.py
@@ -25,7 +25,7 @@ class TestSDK(unittest.TestCase):
             self.assertEqual("127.0.0.1", response.host)
 
         finally:
-            if id is not "":
+            if id != "":
                 stop_request = gnomock.StopRequest(id=id)
                 self.api.stop(stop_request)
 
@@ -43,7 +43,7 @@ class TestSDK(unittest.TestCase):
             self.assertEqual("127.0.0.1", response.host)
 
         finally:
-            if id is not "":
+            if id != "":
                 stop_request = gnomock.StopRequest(id=id)
                 self.api.stop(stop_request)
 
@@ -61,7 +61,7 @@ class TestSDK(unittest.TestCase):
             self.assertEqual("127.0.0.1", response.host)
 
         finally:
-            if id is not "":
+            if id != "":
                 stop_request = gnomock.StopRequest(id=id)
                 self.api.stop(stop_request)
 
@@ -79,7 +79,7 @@ class TestSDK(unittest.TestCase):
             self.assertEqual("127.0.0.1", response.host)
 
         finally:
-            if id is not "":
+            if id != "":
                 stop_request = gnomock.StopRequest(id=id)
                 self.api.stop(stop_request)
 
@@ -97,7 +97,7 @@ class TestSDK(unittest.TestCase):
             self.assertEqual("127.0.0.1", response.host)
 
         finally:
-            if id is not "":
+            if id != "":
                 stop_request = gnomock.StopRequest(id=id)
                 self.api.stop(stop_request)
 
@@ -114,7 +114,7 @@ class TestSDK(unittest.TestCase):
             self.assertEqual("127.0.0.1", response.host)
 
         finally:
-            if id is not "":
+            if id != "":
                 stop_request = gnomock.StopRequest(id=id)
                 self.api.stop(stop_request)
 
@@ -131,7 +131,7 @@ class TestSDK(unittest.TestCase):
             self.assertEqual("127.0.0.1", response.host)
 
         finally:
-            if id is not "":
+            if id != "":
                 stop_request = gnomock.StopRequest(id=id)
                 self.api.stop(stop_request)
 
@@ -150,7 +150,7 @@ class TestSDK(unittest.TestCase):
             self.assertEqual("127.0.0.1", response.host)
 
         finally:
-            if id is not "":
+            if id != "":
                 stop_request = gnomock.StopRequest(id=id)
                 self.api.stop(stop_request)
 
@@ -167,13 +167,17 @@ class TestSDK(unittest.TestCase):
             self.assertEqual("127.0.0.1", response.host)
 
         finally:
-            if id is not "":
+            if id != "":
                 stop_request = gnomock.StopRequest(id=id)
                 self.api.stop(stop_request)
 
     def test_rabbitmq(self):
+        file_name = os.path.abspath("./test/testdata/rabbitmq/messages.jsonl")
         options = gnomock.Options()
-        preset = gnomock.Rabbitmq(version="3.8.5-alpine")
+        message = gnomock.RabbitmqMessage(queue="alerts",
+                content_type="text/plain", string_body="python")
+        preset = gnomock.Rabbitmq(version="3.8.5-alpine",
+                messages_files=[file_name], messages=[message])
         rabbitmq_request = gnomock.RabbitmqRequest(options=options,
                 preset=preset)
         id = ""
@@ -184,7 +188,7 @@ class TestSDK(unittest.TestCase):
             self.assertEqual("127.0.0.1", response.host)
 
         finally:
-            if id is not "":
+            if id != "":
                 stop_request = gnomock.StopRequest(id=id)
                 self.api.stop(stop_request)
 
@@ -202,7 +206,7 @@ class TestSDK(unittest.TestCase):
             self.assertEqual("127.0.0.1", response.host)
 
         finally:
-            if id is not "":
+            if id != "":
                 stop_request = gnomock.StopRequest(id=id)
                 self.api.stop(stop_request)
 
@@ -220,7 +224,7 @@ class TestSDK(unittest.TestCase):
             self.assertEqual("127.0.0.1", response.host)
 
         finally:
-            if id is not "":
+            if id != "":
                 stop_request = gnomock.StopRequest(id=id)
                 self.api.stop(stop_request)
 
@@ -238,7 +242,7 @@ class TestSDK(unittest.TestCase):
             self.assertEqual("127.0.0.1", response.host)
 
         finally:
-            if id is not "":
+            if id != "":
                 stop_request = gnomock.StopRequest(id=id)
                 self.api.stop(stop_request)
 

--- a/sdktest/python/test/testdata/rabbitmq/messages.jsonl
+++ b/sdktest/python/test/testdata/rabbitmq/messages.jsonl
@@ -1,0 +1,3 @@
+{ "queue": "events", "content_type": "text/plain", "string_body": "something else" }
+{ "queue": "alerts", "content_type": "text/plain", "string_body": "memory pressure" }
+{ "queue": "alerts", "content_type": "text/binary", "body": "Z25vbW9jaw==" }

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -879,8 +879,33 @@ components:
           description: RabbitMQ version.
           default: 3.8.5-alpine
           example: latest
+        messages:
+          type: array
+          description: A list of messages to send to RabbitMQ
+          items:
+            $ref: '#/components/schemas/rabbitmqMessage'
+        messages_files:
+          type: array
+          items:
+            type: string
       description: >
         This object describes a RabbitMQ container.
+
+    rabbitmqMessage:
+      type: object
+      properties:
+        queue:
+          type: string
+          example: alerts
+        content_type:
+          type: string
+          example: text/plain
+        string_body:
+          type: string
+          example: high cpu
+        body:
+          type: string
+          format: byte
 
     kafka-request:
       type: object


### PR DESCRIPTION
Initial message setup in rabbitmq preset was missing tests and swagger
specs, and this commit completes the "initialization" feature.