### PR TITLE
Implement preset generator tool

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,6 +215,8 @@ jobs:
           name: Test server
           command: go test -race -cover -v ./internal/gnomockd -run TestK3s
 
+### preset tests go here
+
 workflows:
   build-workflow:
     jobs:
@@ -234,3 +236,4 @@ workflows:
       - test-mssql
       - test-mongo
       - test-k3s
+### circleci jobs go here

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -374,3 +374,4 @@ jobs:
           cat preset-cover.txt server-cover.txt > coverage.txt
           bash <(curl -s https://codecov.io/bash)
 
+### preset tests go here

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ Gnomock:
 
 > Please note that nobody has to go all the way alone. Adding a new Preset can
 > be a collective effort, where some of the task are delegated to somebody else
-> (to me, for example, I'm happy to help)
+> (to me, for example, I'm happy to help).
 
 1. Write an actual preset code with a test. The code goes into
    [`preset`](https://github.com/orlangure/gnomock/tree/master/preset) package.
@@ -95,8 +95,28 @@ Gnomock:
 
 1. Update [README](README.md) using the links to the new packages/docs.
 
-1. Add a job to test the new preset to Github Actions ([here is the
-   workflow](https://github.com/orlangure/gnomock/blob/master/.github/workflows/test.yaml)).
+1. Add a job to test the new preset to [Github
+   Actions](https://github.com/orlangure/gnomock/blob/master/.github/workflows/test.yaml)
+   and
+   [CircleCI](https://github.com/orlangure/gnomock/blob/master/.circleci/config.yml).
+
+#### Preset Generator
+
+You can use a [preset
+generator](https://github.com/orlangure/gnomock/blob/master/cmd/generator) to
+automate the boring part of the above checklist:
+
+```bash
+# from Gnomock root with clean `git status`
+go run ./cmd/generator \
+    -name PresetName \              # e.g Postgres, CockroachDB or MySQL
+    -default-port 12345 \           # use any value if unsure, this is easily fixed
+    -image docker.io/author/image \ # note the full name, including the registry
+    -public                         # omit this flag if you need a preset for yourself only
+```
+
+Carefully review all the files that were added/changed by this command, and
+implement the actual logic. Start with health check function.
 
 ## Code review
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ services running in ephemeral Docker containers:
 
 - [Getting started](#getting-started)
   - [Using Gnomock in Go applications](#using-gnomock-in-go-applications)
-  - [Using Gnomock server](#using-gnomock-server)
+  - [Using Gnomock in other languages](#using-gnomock-in-other-languages)
 - [Official presets](#official-presets)
 - [Similar projects](#similar-projects)
 - [Troubleshooting](#troubleshooting)
@@ -97,7 +97,11 @@ See package
 [reference](https://pkg.go.dev/github.com/orlangure/gnomock?tab=doc). For
 Preset documentation, refer to [Presets](#official-presets) section.
 
-### Using Gnomock server
+### Using Gnomock in other languages
+
+If you use Go, please refer to [Using Gnomock in Go
+applications](#using-gnomock-in-go-applications) section. Otherwise, you'll
+need to setup a helper container, and communicate with it over HTTP.
 
 To start a `gnomock` server, run the following on any Unix-based system:
 
@@ -193,8 +197,11 @@ RabbitMQ | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/
 Kafka | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/kafka) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.4.6#/presets/startKafka) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/kafka?tab=doc) | `2.5.1-L0`
 Elasticsearch | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/elastic) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.4.6#/presets/startElastic) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/elastic?tab=doc) | `5.6`, `6.8.13`, `7.9.3`
 Kubernetes | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/k3s) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.4.6#/presets/startKubernetes) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/k3s?tab=doc) | `v1.19.3`
-DynamoDB | |
-Cassandra | |
+<!-- new presets go here -->
+
+Please note that "Supported versions" means that only these versions are
+tested. There is a chance that other versions work as well, unless they are
+very new with breaking changes, or very old and no longer supported by anybody.
 
 It is possible to use Gnomock directly from Go code without any presets. HTTP
 API only allows to setup containers using presets that exist in this

--- a/cmd/generator/main.go
+++ b/cmd/generator/main.go
@@ -1,0 +1,345 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+	"strings"
+	"text/template"
+)
+
+const (
+	registryPlaceholder = `/// new presets go here
+`
+	pytestPlaceholder = `### gnomock-generator
+`
+	startPresetPlaceholder = `### /start/preset
+`
+	requestBodyPlaceholder = `### preset-request
+`
+	readmePlaceholder = `<!-- new presets go here -->
+`
+	ciTestPlaceholder = `### preset tests go here
+`
+	circleciJobsPlaceholder = `### circleci jobs go here
+`
+)
+
+var fMap = template.FuncMap{
+	"lower": strings.ToLower,
+}
+
+type presetParams struct {
+	Name        string
+	DefaultPort int
+	Image       string
+	Public      bool
+}
+
+func main() {
+	if err := generate(); err != nil {
+		log.Fatalln(err)
+	}
+
+	log.Println("done")
+}
+
+func generate() error {
+	var pp presetParams
+
+	flag.StringVar(&pp.Name, "name", "", `new preset name, e.g "Redis", "Postgres", etc.`)
+	flag.StringVar(&pp.Image, "image", "", "full docker image name")
+	flag.IntVar(&pp.DefaultPort, "default-port", 0, "default TCP Port to use")
+	flag.BoolVar(&pp.Public, "public", false, "prepare this preset for public use")
+	flag.Parse()
+
+	if err := presetPkg(pp); err != nil {
+		return err
+	}
+
+	if pp.Public {
+		if err := gnomockdPkg(pp); err != nil {
+			return err
+		}
+
+		if err := registry(pp); err != nil {
+			return err
+		}
+
+		if err := sdktestPkg(pp); err != nil {
+			return err
+		}
+
+		if err := swagger(pp); err != nil {
+			return err
+		}
+
+		if err := readme(pp); err != nil {
+			return err
+		}
+
+		if err := github(pp); err != nil {
+			return err
+		}
+
+		if err := circleci(pp); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// presetPkg generates a minimal working version of a preset. It also creates a
+// README.md file that needs to be manually edited when the preset is ready.
+func presetPkg(params presetParams) error {
+	dir := path.Join("preset", strings.ToLower(params.Name))
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		return fmt.Errorf("can't create preset folder: %w", err)
+	}
+
+	files := []string{"preset.go", "preset_test.go", "options.go", "README.md"}
+	for _, file := range files {
+		if err := presetFile(dir, file, params); err != nil {
+			return fmt.Errorf("can't generate preset file: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func presetFile(dir, file string, params presetParams) error {
+	fName := fmt.Sprintf("%s.template", file)
+
+	tmpl, err := template.New(fName).Funcs(fMap).ParseFiles(path.Join("cmd/generator/templates/preset", fName))
+	if err != nil {
+		return fmt.Errorf("can't parse template: %w", err)
+	}
+
+	presetFile := path.Join(dir, file)
+
+	f, err := os.Create(presetFile)
+	if err != nil {
+		return fmt.Errorf("can't create new file: %w", err)
+	}
+
+	defer func() {
+		if err := f.Close(); err != nil {
+			log.Println("can't close file:", err)
+		}
+	}()
+
+	if err := tmpl.Execute(f, params); err != nil {
+		return fmt.Errorf("can't execute template: %w", err)
+	}
+
+	return nil
+}
+
+// gnomockdPkg adds the preset tests to gnomockd package.
+func gnomockdPkg(params presetParams) error {
+	gnomockdPath := path.Join("internal", "gnomockd")
+	testdataPath := path.Join(gnomockdPath, "testdata")
+
+	dir := path.Join(testdataPath, strings.ToLower(params.Name))
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		return fmt.Errorf("can't create testdata dir: %s", err)
+	}
+
+	presetFileName := fmt.Sprintf("%s.json", strings.ToLower(params.Name))
+
+	presetFile, err := os.Create(path.Join(testdataPath, presetFileName))
+	if err != nil {
+		return fmt.Errorf("can't create preset file: %w", err)
+	}
+
+	defer func() {
+		if err := presetFile.Close(); err != nil {
+			log.Println("can't close file:", err)
+		}
+	}()
+
+	if err := json.NewEncoder(presetFile).Encode(map[string]interface{}{
+		"preset": map[string]interface{}{
+			"version": "latest",
+		},
+		"options": map[string]interface{}{
+			"debug": true,
+		},
+	}); err != nil {
+		return fmt.Errorf("can't write into preset file: %w", err)
+	}
+
+	presetTestTemplate := "cmd/generator/templates/gnomockd/preset_test.go.template"
+
+	tmpl, err := template.New("preset_test.go.template").Funcs(fMap).ParseFiles(presetTestTemplate)
+	if err != nil {
+		return fmt.Errorf("can't parse template: %w", err)
+	}
+
+	testFile := path.Join(gnomockdPath, fmt.Sprintf("%s_test.go", strings.ToLower(params.Name)))
+
+	f, err := os.Create(testFile)
+	if err != nil {
+		return fmt.Errorf("can't create new file: %w", err)
+	}
+
+	defer func() {
+		if err := f.Close(); err != nil {
+			log.Println("can't close file:", err)
+		}
+	}()
+
+	if err := tmpl.Execute(f, params); err != nil {
+		return fmt.Errorf("can't execute template: %w", err)
+	}
+
+	return nil
+}
+
+// registry adds the new preset to gnomockd preset registry so that it becomes
+// available over HTTP.
+func registry(params presetParams) error {
+	if err := replacePlaceholder(
+		path.Join("cmd", "server", "presets.go"),
+		"cmd/generator/templates/cmd/server/presets.go.template",
+		registryPlaceholder,
+		params,
+	); err != nil {
+		return fmt.Errorf("can't generate registry code: %w", err)
+	}
+
+	return nil
+}
+
+// sdktestPkg generates code required for testing the generated SDK. It creates
+// a `testdata` folder for a new preset and adds a test stub to `test_sdk.py`.
+//
+// Test generator is the most basic possible: it will generate wrong names for
+// any preset that doesn't have a single word, simple case name like "Redis" or
+// "Kubernetes": names like RabbitMQ will break.
+func sdktestPkg(params presetParams) error {
+	testPath := path.Join("sdktest", "python", "test")
+	dir := path.Join(testPath, "testdata", strings.ToLower(params.Name))
+
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		return fmt.Errorf("can't create testdata dir: %w", err)
+	}
+
+	pytestFileName := path.Join(testPath, "test_sdk.py")
+
+	if err := replacePlaceholder(
+		pytestFileName,
+		"cmd/generator/templates/sdktest/python/test/test_sdk.py.template",
+		pytestPlaceholder,
+		params,
+	); err != nil {
+		return fmt.Errorf("can't generate python tests: %w", err)
+	}
+
+	return nil
+}
+
+// swagger generates new definitions in swagger.yaml file. These definitions
+// should be extended with options supported by a new preset.
+func swagger(params presetParams) error {
+	swaggerFile := path.Join("swagger", "swagger.yaml")
+
+	if err := replacePlaceholder(
+		swaggerFile,
+		"cmd/generator/swagger/start.template",
+		startPresetPlaceholder,
+		params,
+	); err != nil {
+		return fmt.Errorf("can't generate swagger spec: %w", err)
+	}
+
+	if err := replacePlaceholder(
+		swaggerFile,
+		"cmd/generator/swagger/body.template",
+		requestBodyPlaceholder,
+		params,
+	); err != nil {
+		return fmt.Errorf("can't generate swagger spec: %w", err)
+	}
+
+	return nil
+}
+
+func readme(params presetParams) error {
+	return replacePlaceholder(
+		"README.md",
+		"cmd/generator/templates/README.md.template",
+		readmePlaceholder,
+		params,
+	)
+}
+
+func github(params presetParams) error {
+	return replacePlaceholder(
+		path.Join(".github", "workflows", "test.yaml"),
+		"cmd/generator/templates/.github/workflows/test.yaml.template",
+		ciTestPlaceholder,
+		params,
+	)
+}
+
+func circleci(params presetParams) error {
+	circleciPath := path.Join(".circleci", "config.yml")
+
+	if err := replacePlaceholder(
+		circleciPath,
+		"cmd/generator/templates/.circleci/config.yml.template",
+		ciTestPlaceholder,
+		params,
+	); err != nil {
+		return fmt.Errorf("can't create circleci job: %w", err)
+	}
+
+	if err := replacePlaceholder(
+		circleciPath,
+		"cmd/generator/templates/.circleci/jobs.template",
+		circleciJobsPlaceholder,
+		params,
+	); err != nil {
+		return fmt.Errorf("can't add circleci job to config.yml: %w", err)
+	}
+
+	return nil
+}
+
+// replacePlaceholder replaces `placeholder` in `targetFile` with the result of
+// `tmplFile` template execution using `params` values.
+//
+// nolint:gosec
+func replacePlaceholder(targetFile, tmplFile, placeholder string, params presetParams) error {
+	targetBs, err := ioutil.ReadFile(targetFile)
+	if err != nil {
+		return fmt.Errorf("can't read %s: %w", targetFile, err)
+	}
+
+	tmplName := path.Base(tmplFile)
+
+	tmpl, err := template.New(tmplName).Funcs(fMap).ParseFiles(tmplFile)
+	if err != nil {
+		return fmt.Errorf("can't read %s: %w", tmplName, err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, params); err != nil {
+		return fmt.Errorf("can't execute template: %w", err)
+	}
+
+	targetStr := strings.ReplaceAll(string(targetBs), placeholder, buf.String())
+
+	if err := ioutil.WriteFile(targetFile, []byte(targetStr), 0644); err != nil {
+		return fmt.Errorf("can't write %s: %w", targetFile, err)
+	}
+
+	return nil
+}

--- a/cmd/generator/swagger/body.template
+++ b/cmd/generator/swagger/body.template
@@ -1,0 +1,22 @@
+    {{ lower .Name }}-request:
+      type: object
+      properties:
+        preset:
+          $ref: '#/components/schemas/{{ lower .Name }}'
+        options:
+          $ref: '#/components/schemas/options'
+      description: >
+        This request includes {{ .Name }} and general configuration.
+
+    {{ lower .Name }}:
+      type: object
+      properties:
+        # TODO: add supported parameters
+        version:
+          type: string
+          description: Docker image tag (version)
+          default: latest
+      description: >
+        This object describes {{ .Name }} container.
+
+### preset-request

--- a/cmd/generator/swagger/start.template
+++ b/cmd/generator/swagger/start.template
@@ -1,0 +1,21 @@
+  /start/{{ lower .Name }}:
+    post:
+      summary: Start a new Gnomock {{ .Name }} preset.
+      operationId: start{{ .Name }}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/{{ lower .Name }}-request'
+      responses:
+        '200':
+          $ref: '#/components/responses/container-created'
+        '400':
+          $ref: '#/components/responses/invalid-configuration'
+        '500':
+          $ref: '#/components/responses/start-failed'
+      tags:
+        - presets
+
+### /start/preset

--- a/cmd/generator/templates/.circleci/config.yml.template
+++ b/cmd/generator/templates/.circleci/config.yml.template
@@ -1,0 +1,12 @@
+  test-{{ lower .Name }}:
+    machine: true
+    steps:
+      - setup-for-go-test
+      - run:
+          name: Test preset
+          command: go test -race -cover -v ./preset/{{ lower .Name }}/...
+      - run:
+          name: Test server
+          command: go test -race -cover -v ./internal/gnomockd -run Test{{ .Name }}
+
+### preset tests go here

--- a/cmd/generator/templates/.circleci/jobs.template
+++ b/cmd/generator/templates/.circleci/jobs.template
@@ -1,0 +1,2 @@
+      - test-{{ lower .Name }}
+### circleci jobs go here

--- a/cmd/generator/templates/.github/workflows/test.yaml.template
+++ b/cmd/generator/templates/.github/workflows/test.yaml.template
@@ -1,0 +1,24 @@
+  test-{{ lower .Name }}:
+    name: "[preset] {{ lower .Name }}"
+    runs-on: ubuntu-latest
+    env:
+      CODECOV_TOKEN: ${{ `{{ secrets.CODECOV_TOKEN }}` }}
+    steps:
+      - name: Set up Go 1.15
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.15
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+      - name: Get dependencies
+        run: go get -v -t -d ./...
+      - name: Test preset
+        run: go test -race -cover -coverprofile=preset-cover.txt -coverpkg=./... -v ./preset/{{ lower .Name }}/...
+      - name: Test server
+        run: go test -race -cover -coverprofile=server-cover.txt -coverpkg=./... -v ./internal/gnomockd -run Test{{ .Name }}
+      - name: Report coverage
+        run: |
+          cat preset-cover.txt server-cover.txt > coverage.txt
+          bash <(curl -s https://codecov.io/bash)
+
+### preset tests go here

--- a/cmd/generator/templates/README.md.template
+++ b/cmd/generator/templates/README.md.template
@@ -1,0 +1,3 @@
+<!-- TODO: make sure names below are correct, and replace `latest` with an actual version -->
+{{ .Name }} | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/{{ lower .Name }}) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.4.6#/presets/start{{ .Name }}) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/{{ lower .Name }}?tab=doc) | `latest`
+<!-- new presets go here -->

--- a/cmd/generator/templates/cmd/server/presets.go.template
+++ b/cmd/generator/templates/cmd/server/presets.go.template
@@ -1,0 +1,2 @@
+_ "github.com/orlangure/gnomock/preset/{{ lower .Name }}"
+	/// new presets go here

--- a/cmd/generator/templates/gnomockd/preset_test.go.template
+++ b/cmd/generator/templates/gnomockd/preset_test.go.template
@@ -1,0 +1,52 @@
+package gnomockd_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/orlangure/gnomock"
+	"github.com/orlangure/gnomock/internal/gnomockd"
+	_ "github.com/orlangure/gnomock/preset/{{ lower .Name }}"
+	"github.com/stretchr/testify/require"
+)
+
+func Test{{ .Name }}(t *testing.T) {
+	t.Parallel()
+
+	h := gnomockd.Handler()
+	bs, err := ioutil.ReadFile("./testdata/{{ lower .Name }}.json")
+	require.NoError(t, err)
+
+	buf := bytes.NewBuffer(bs)
+	w, r := httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/start/{{ lower .Name }}", buf)
+	h.ServeHTTP(w, r)
+
+	res := w.Result()
+
+	defer func() { require.NoError(t, res.Body.Close()) }()
+
+	body, err := ioutil.ReadAll(res.Body)
+	require.NoError(t, err)
+
+	require.Equalf(t, http.StatusOK, res.StatusCode, string(body))
+
+	var c *gnomock.Container
+
+	err = json.Unmarshal(body, &c)
+	require.NoError(t, err)
+	require.NotEmpty(t, c.DefaultAddress())
+
+	bs, err = json.Marshal(c)
+	require.NoError(t, err)
+
+	buf = bytes.NewBuffer(bs)
+	w, r = httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/stop", buf)
+	h.ServeHTTP(w, r)
+
+	res = w.Result()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+}

--- a/cmd/generator/templates/preset/README.md.template
+++ b/cmd/generator/templates/preset/README.md.template
@@ -1,0 +1,11 @@
+# Gnomock {{ .Name }}
+
+Gnomock {{ .Name }} is a [Gnomock](https://github.com/orlangure/gnomock) preset for
+running tests against a real {{ .Name }} container, without mocks.
+
+```go
+package {{ lower .Name }}_test
+
+// TODO: insert test code here
+```
+

--- a/cmd/generator/templates/preset/options.go.template
+++ b/cmd/generator/templates/preset/options.go.template
@@ -1,0 +1,12 @@
+package {{ lower .Name }}
+
+// Option is an optional configuration of this Gnomock preset. Use available
+// Options to configure the container.
+type Option func(*P)
+
+// WithVersion sets image version.
+func WithVersion(version string) Option {
+	return func(o *P) {
+		o.Version = version
+	}
+}

--- a/cmd/generator/templates/preset/preset.go.template
+++ b/cmd/generator/templates/preset/preset.go.template
@@ -1,0 +1,79 @@
+// Package {{ lower .Name }} includes {{ .Name }} implementation of Gnomock Preset interface.
+// This Preset can be passed to gnomock.Start() function to create a configured
+// {{ .Name }} container to use in tests.
+package {{ lower .Name }}
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/orlangure/gnomock"
+	{{ if .Public -}}
+	"github.com/orlangure/gnomock/internal/registry"
+	{{- end}}
+)
+
+// TODO: use a pinned-down version
+const defaultVersion = "latest"
+// TODO: if needed, add/modify ports here and in Ports method
+const defaultPort = {{ .DefaultPort }}
+
+{{ if .Public -}}
+func init() {
+	registry.Register("{{ lower .Name }}", func() gnomock.Preset { return &P{} })
+}
+{{ end -}}
+
+// Preset creates a new Gmomock {{ .Name }} preset. This preset includes a {{ .Name }}
+// specific healthcheck function and default {{ .Name }} image and port.
+func Preset(opts ...Option) gnomock.Preset {
+	p := &P{}
+
+	for _, opt := range opts {
+		opt(p)
+	}
+
+	return p
+}
+
+// P is a Gnomock Preset implementation for {{ .Name }}.
+type P struct {
+	Version string `json:"version"`
+	// TODO: add fields specific to this preset
+}
+
+// Image returns an image that should be pulled to create this container.
+func (p *P) Image() string {
+	return fmt.Sprintf("{{ .Image }}:%s", p.Version)
+}
+
+// Ports returns ports that should be used to access this container.
+func (p *P) Ports() gnomock.NamedPorts {
+	return gnomock.DefaultTCP(defaultPort)
+}
+
+// Options returns a list of options to configure this container.
+func (p *P) Options() []gnomock.Option {
+	p.setDefaults()
+
+	opts := []gnomock.Option{
+		gnomock.WithHealthCheck(healthcheck),
+	}
+
+	// TODO: add init func here if preset supports setting up initial state
+
+	return opts
+}
+
+func (p *P) setDefaults() {
+	if p.Version == "" {
+		p.Version = defaultVersion
+	}
+}
+
+func healthcheck(ctx context.Context, c *gnomock.Container) error {
+	// TODO: return non-nil error unless the container becomes available
+	// addr := c.Address(gnomock.DefaultPort)
+
+	return nil
+}

--- a/cmd/generator/templates/preset/preset_test.go.template
+++ b/cmd/generator/templates/preset/preset_test.go.template
@@ -1,0 +1,36 @@
+package {{ lower .Name }}_test
+
+import (
+	"testing"
+
+	"github.com/orlangure/gnomock"
+	"github.com/orlangure/gnomock/preset/{{ lower .Name }}"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPreset(t *testing.T) {
+	t.Parallel()
+
+	// TODO: use versions (tags) this preset supports
+	for _, version := range []string{"latest"} {
+		t.Run(version, testPreset(version))
+	}
+}
+
+func testPreset(version string) func(t *testing.T) {
+	return func(t *testing.T) {
+		p := {{ lower .Name }}.Preset(
+			{{ lower .Name }}.WithVersion(version),
+		)
+		container, err := gnomock.Start(p)
+
+		defer func() { require.NoError(t, gnomock.Stop(container)) }()
+
+		require.NoError(t, err)
+
+		addr := container.DefaultAddress()
+		require.NotEmpty(t, addr)
+	}
+}
+
+// TODO: add tests to ensure solid coverage

--- a/cmd/generator/templates/sdktest/python/test/test_sdk.py.template
+++ b/cmd/generator/templates/sdktest/python/test/test_sdk.py.template
@@ -1,0 +1,20 @@
+    def test_{{ lower .Name }}(self):
+		# TODO: make sure names below match the code
+        options = gnomock.Options(debug=True)
+        preset = gnomock.{{ .Name }}(version="latest")
+        {{ lower .Name }}_request = gnomock.{{ .Name }}Request(options=options,
+                preset=preset)
+        id = ""
+
+        try:
+            response = self.api.start_{{ lower .Name }}({{ lower .Name }}_request)
+            id = response.id
+            self.assertEqual("127.0.0.1", response.host)
+
+        finally:
+            if id != "":
+                stop_request = gnomock.StopRequest(id=id)
+                self.api.stop(stop_request)
+
+
+### gnomock-generator

--- a/cmd/server/presets.go
+++ b/cmd/server/presets.go
@@ -16,4 +16,5 @@ import (
 	_ "github.com/orlangure/gnomock/preset/rabbitmq"
 	_ "github.com/orlangure/gnomock/preset/redis"
 	_ "github.com/orlangure/gnomock/preset/splunk"
+	/// new presets go here
 )

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+ignore:
+  # generator is a supporting utility built for humans; it isn't an integral
+  # part of Gnomock
+  - cmd/generator/**/*

--- a/preset/redis/preset.go
+++ b/preset/redis/preset.go
@@ -1,6 +1,6 @@
 // Package redis includes Redis implementation of Gnomock Preset interface.
-// This Preset can be passed to gnomock.StartPreset function to create a
-// configured Redis container to use in tests
+// This Preset can be passed to gnomock.Start() function to create a configured
+// Redis container to use in tests.
 package redis
 
 import (

--- a/sdktest/python/test/test_sdk.py
+++ b/sdktest/python/test/test_sdk.py
@@ -247,5 +247,8 @@ class TestSDK(unittest.TestCase):
                 self.api.stop(stop_request)
 
 
+### gnomock-generator
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -266,6 +266,9 @@ paths:
           $ref: '#/components/responses/start-failed'
       tags:
         - presets
+
+### /start/preset
+
   /stop:
     post:
       summary: Stop an existing Gnomock container
@@ -1015,6 +1018,8 @@ components:
           example: latest
       description: >
         This object describes a k3s container.
+
+### preset-request
 
     stop-request:
       type: object


### PR DESCRIPTION
This is the first attempt to build a CLI utility to generate Gnomock
Presets. It allows to easily generate boilerplate code for new presets
that are about to enter Gnomock ecosystem.

This tool generates preset code itself (should be fully working but
pretty useless), test code, server-related code to support the preset
over HTTP, swagger spec and more.

Of course human intervention is required to build actual presets. For
example, healthcheck function is the bare minimum that needs to be added
to make the preset useful. Initial state setup functions should also be
added wherever possible, but not mandatory.

This tool leaves a bunch of TODO comments wherever users need to make
manual changes.

Closes #68 