### PR TITLE
Add new linters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,8 @@ jobs:
       - run:
           name: golangci-lint
           command: |
-            curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.23.8
-            $(go env GOPATH)/bin/golangci-lint run ./... --timeout 4m0s
+            curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.39.0
+            $(go env GOPATH)/bin/golangci-lint run ./... --timeout 10m0s
 
   test-core:
     machine: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,9 +18,9 @@ jobs:
       - name: Get dependencies
         run: go get -v -t -d ./...
       - name: Get golangci-lint
-        run: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.23.8
+        run: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.39.0
       - name: Lint
-        run: $(go env GOPATH)/bin/golangci-lint run --timeout 2m0s ./...
+        run: $(go env GOPATH)/bin/golangci-lint run --timeout 10m0s ./...
 
   test-core:
     name: "[core] gnomock, gnomockd"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,39 +1,50 @@
 linters:
   enable:
-    - deadcode
-    - errcheck
-    - gosimple
-    - govet
-    - ineffassign
-    - staticcheck
-    - structcheck
-    - typecheck
-    - unused
-    - varcheck
     - bodyclose
+    - cyclop
+    - deadcode
     - depguard
     - dogsled
+    - errcheck
+    - exportloopref
+    - forcetypeassert
     - funlen
+    - errorlint
     - gocognit
     - goconst
     - gocritic
     - gocyclo
+    - godot
     - godox
     - gofmt
+    - gofumpt
     - goimports
     - golint
     - goprintffuncname
     - gosec
-    - interfacer
+    - gosimple
+    - govet
+    - ifshort
+    - ineffassign
     - lll
     - misspell
     - nakedret
+    - nilerr
+    - noctx
     - prealloc
+    - predeclared
+    - revive
     - rowserrcheck
-    - scopelint
+    - sqlclosecheck
+    - staticcheck
+    - structcheck
     - stylecheck
+    - typecheck
     - unconvert
     - unparam
+    - unused
+    - varcheck
+    - wastedassign
     - whitespace
     - wsl
 
@@ -44,3 +55,12 @@ issues:
         - funlen
         - bodyclose
         - gosec
+        - noctx
+
+    - path: cmd/server/presets.go
+      linters:
+        - godot
+
+    - path: internal/testutil/preset.go
+      linters:
+        - godot

--- a/cmd/generator/main.go
+++ b/cmd/generator/main.go
@@ -161,7 +161,7 @@ func gnomockdPkg(params presetParams) error {
 
 	dir := path.Join(testdataPath, strings.ToLower(params.Name))
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
-		return fmt.Errorf("can't create testdata dir: %s", err)
+		return fmt.Errorf("can't create testdata dir: %w", err)
 	}
 
 	presetFileName := fmt.Sprintf("%s.json", strings.ToLower(params.Name))

--- a/cmd/generator/main.go
+++ b/cmd/generator/main.go
@@ -31,8 +31,10 @@ const (
 `
 )
 
-var matchFirstCap = regexp.MustCompile("(.)([A-Z][a-z]+)")
-var matchAllCap = regexp.MustCompile("([a-z0-9])([A-Z])")
+var (
+	matchFirstCap = regexp.MustCompile("(.)([A-Z][a-z]+)")
+	matchAllCap   = regexp.MustCompile("([a-z0-9])([A-Z])")
+)
 
 var fMap = template.FuncMap{
 	"lower": strings.ToLower,

--- a/container.go
+++ b/container.go
@@ -8,7 +8,7 @@ import (
 
 // Container represents a docker container created for testing. Host and Ports
 // fields should be used to configure the connection to this container. ID
-// matches the original docker container ID
+// matches the original docker container ID.
 type Container struct {
 	// A unique identifier of this container. The format of this ID may change
 	// in the future.
@@ -30,7 +30,7 @@ type Container struct {
 // Address is a convenience function that returns host:port that can be used to
 // connect to this container. If a container was created with DefaultTCP call,
 // use DefaultPort as the name. Otherwise, use the name of one of the ports
-// used during setup
+// used during setup.
 func (c *Container) Address(name string) string {
 	p := c.Port(name)
 	if p == 0 {
@@ -40,18 +40,18 @@ func (c *Container) Address(name string) string {
 	return fmt.Sprintf("%s:%d", c.Host, p)
 }
 
-// DefaultAddress return Address() with DefaultPort
+// DefaultAddress return Address() with DefaultPort.
 func (c *Container) DefaultAddress() string {
 	return c.Address(DefaultPort)
 }
 
 // Port is a convenience function that returns port number with the provided
-// name
+// name.
 func (c *Container) Port(name string) int {
 	return c.Ports.Get(name).Port
 }
 
-// DefaultPort returns Port() with DefaultPort
+// DefaultPort returns Port() with DefaultPort.
 func (c *Container) DefaultPort() int {
 	return c.Port(DefaultPort)
 }

--- a/docker.go
+++ b/docker.go
@@ -19,10 +19,12 @@ import (
 	"go.uber.org/zap"
 )
 
-const localhostAddr = "127.0.0.1"
-const defaultStopTimeout = time.Second * 1
-const duplicateContainerPattern = `Conflict. The container name "(?:.+?)" is already in use by container "(\w+)". You have to remove \(or rename\) that container to be able to reuse that name.` // nolint:lll
-const dockerSockAddr = "/var/run/docker.sock"
+const (
+	localhostAddr             = "127.0.0.1"
+	defaultStopTimeout        = time.Second * 1
+	duplicateContainerPattern = `Conflict. The container name "(?:.+?)" is already in use by container "(\w+)". You have to remove \(or rename\) that container to be able to reuse that name.` // nolint:lll
+	dockerSockAddr            = "/var/run/docker.sock"
+)
 
 type docker struct {
 	client *client.Client
@@ -70,6 +72,10 @@ func (d *docker) pullImage(ctx context.Context, image string) error {
 
 func (d *docker) startContainer(ctx context.Context, image string, ports NamedPorts, cfg *Options) (*Container, error) {
 	d.log.Info("starting container")
+
+	if err := d.pullImage(ctx, image); err != nil {
+		return nil, fmt.Errorf("can't pull image: %w", err)
+	}
 
 	resp, err := d.createContainer(ctx, image, ports, cfg)
 	if err != nil {

--- a/errors.go
+++ b/errors.go
@@ -4,5 +4,5 @@ import "fmt"
 
 // ErrEnvClient means that Gnomock can't connect to docker daemon in the
 // testing environment. See https://docs.docker.com/compose/reference/overview/
-// for information on required configuration
+// for information on required configuration.
 var ErrEnvClient = fmt.Errorf("can't connect to docker host")

--- a/gnomock_internal_test.go
+++ b/gnomock_internal_test.go
@@ -25,10 +25,10 @@ func TestWaitForContainerNetwork(t *testing.T) {
 		testImage, namedPorts,
 		WithTimeout(time.Second*10),
 	)
-	id, _ := parseID(container.ID)
-
 	require.NoError(t, err)
 	require.NotNil(t, container)
+
+	id, _ := parseID(container.ID)
 
 	gg, err := newG(false)
 	require.NoError(t, err)

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -2,6 +2,7 @@
 package errors
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -102,10 +103,10 @@ func (e stopFailedError) Error() string {
 
 // ErrorCode returns HTTP response code for the provided error
 func ErrorCode(err error) int {
-	switch err.(type) {
-	case invalidStartRequestError, invalidStopRequestError:
+	switch {
+	case errors.As(err, &invalidStartRequestError{}), errors.As(err, &invalidStopRequestError{}):
 		return http.StatusBadRequest
-	case presetNotFoundError:
+	case errors.As(err, &presetNotFoundError{}):
 		return http.StatusNotFound
 	default:
 		return http.StatusInternalServerError

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -28,7 +28,7 @@ func (e presetNotFoundError) Error() string {
 }
 
 // NewInvalidStartRequestError means that the request parameters of /start call
-// were invalid
+// were invalid.
 func NewInvalidStartRequestError(err error) error {
 	return invalidStartRequestError{
 		err:    err,
@@ -45,7 +45,8 @@ func (e invalidStartRequestError) Error() string {
 	return e.ErrStr
 }
 
-// NewStartFailedError means that the container failed to start for some reason
+// NewStartFailedError means that the container failed to start for some
+// reason.
 func NewStartFailedError(err error, c *gnomock.Container) error {
 	return startFailedError{
 		err:       err,
@@ -65,7 +66,7 @@ func (e startFailedError) Error() string {
 }
 
 // InvalidStopRequestError means that the request parameters of /stop call were
-// invalid
+// invalid.
 func InvalidStopRequestError(err error) error {
 	return invalidStopRequestError{
 		err:    err,
@@ -82,7 +83,7 @@ func (e invalidStopRequestError) Error() string {
 	return e.ErrStr
 }
 
-// StopFailedError means that the container failed to stop
+// StopFailedError means that the container failed to stop.
 func StopFailedError(err error, c *gnomock.Container) error {
 	return stopFailedError{
 		err:       err,
@@ -101,7 +102,7 @@ func (e stopFailedError) Error() string {
 	return e.ErrStr
 }
 
-// ErrorCode returns HTTP response code for the provided error
+// ErrorCode returns HTTP response code for the provided error.
 func ErrorCode(err error) int {
 	switch {
 	case errors.As(err, &invalidStartRequestError{}), errors.As(err, &invalidStopRequestError{}):

--- a/internal/gnomockd/gnomockd.go
+++ b/internal/gnomockd/gnomockd.go
@@ -10,7 +10,7 @@ import (
 	"github.com/orlangure/gnomock/internal/errors"
 )
 
-// Handler returns an HTTP handler ready to serve incoming connections
+// Handler returns an HTTP handler ready to serve incoming connections.
 func Handler() http.Handler {
 	router := mux.NewRouter()
 	router.HandleFunc("/start/{name}", startHandler()).Methods(http.MethodPost)
@@ -18,6 +18,7 @@ func Handler() http.Handler {
 
 	return router
 }
+
 func respondWithError(w http.ResponseWriter, err error) {
 	w.WriteHeader(errors.ErrorCode(err))
 

--- a/internal/testutil/preset.go
+++ b/internal/testutil/preset.go
@@ -54,9 +54,5 @@ func Healthcheck(ctx context.Context, c *gnomock.Container) error {
 		return err
 	}
 
-	if err := health.HTTPGet(ctx, c.Address("web8080")); err != nil {
-		return err
-	}
-
-	return nil
+	return health.HTTPGet(ctx, c.Address("web8080"))
 }

--- a/options.go
+++ b/options.go
@@ -7,16 +7,18 @@ import (
 	"time"
 )
 
-const defaultTimeout = time.Second * 300
-const defaultHealthcheckInterval = time.Millisecond * 250
+const (
+	defaultTimeout             = time.Second * 300
+	defaultHealthcheckInterval = time.Millisecond * 250
+)
 
 // Option is an optional Gnomock configuration. Functions implementing this
 // signature may be combined to configure Gnomock containers for different use
-// cases
+// cases.
 type Option func(*Options)
 
 // WithContext sets the provided context to be used for setting up a Gnomock
-// container. Canceling this context will cause Start() to abort
+// container. Canceling this context will cause Start() to abort.
 func WithContext(ctx context.Context) Option {
 	return func(o *Options) {
 		o.ctx = ctx
@@ -26,7 +28,7 @@ func WithContext(ctx context.Context) Option {
 // WithInit lets the provided InitFunc to be called when a Gnomock container is
 // created, but before Start() returns. Use this function to run arbitrary code
 // on the new container before using it. It can be useful to bring the
-// container to a certain state (e.g create SQL schema)
+// container to a certain state (e.g create SQL schema).
 func WithInit(f InitFunc) Option {
 	return func(o *Options) {
 		o.init = f
@@ -36,7 +38,7 @@ func WithInit(f InitFunc) Option {
 // WithHealthCheck allows to define a rule to consider a Gnomock container
 // ready to use. For example, it can attempt to connect to this container, and
 // return an error on any failure, or nil on success. This function is called
-// repeatedly until the timeout is reached, or until a nil error is returned
+// repeatedly until the timeout is reached, or until a nil error is returned.
 func WithHealthCheck(f HealthcheckFunc) Option {
 	return func(o *Options) {
 		o.healthcheck = f
@@ -44,7 +46,7 @@ func WithHealthCheck(f HealthcheckFunc) Option {
 }
 
 // WithHealthCheckInterval defines an interval between two consecutive health
-// check calls. This is a constant interval
+// check calls. This is a constant interval.
 func WithHealthCheckInterval(t time.Duration) Option {
 	return func(o *Options) {
 		o.healthcheckInterval = t
@@ -61,7 +63,7 @@ func WithTimeout(t time.Duration) Option {
 }
 
 // WithEnv adds environment variable to the container. For example,
-// AWS_ACCESS_KEY_ID=FOOBARBAZ
+// `AWS_ACCESS_KEY_ID=FOOBARBAZ`.
 func WithEnv(env string) Option {
 	return func(o *Options) {
 		o.Env = append(o.Env, env)
@@ -69,7 +71,7 @@ func WithEnv(env string) Option {
 }
 
 // WithLogWriter sets the target where to write container logs. This can be
-// useful for debugging
+// useful for debugging.
 func WithLogWriter(w io.Writer) Option {
 	return func(o *Options) {
 		o.logWriter = w
@@ -109,7 +111,7 @@ func WithPrivileged() Option {
 // optional configuration.
 //
 // This way has its own limitations. For example, context or initialization
-// functions cannot be set in this way
+// functions cannot be set in this way.
 func WithOptions(options *Options) Option {
 	return func(o *Options) {
 		if options.Timeout > 0 {
@@ -156,7 +158,7 @@ func WithDisableAutoCleanup() Option {
 // It receives a host and a port, and returns an error if the container is not
 // ready, or nil when the container can be used. One example of HealthcheckFunc
 // would be an attempt to establish the same connection to the container that
-// the application under test uses
+// the application under test uses.
 type HealthcheckFunc func(context.Context, *Container) error
 
 func nopHealthcheck(context.Context, *Container) error {
@@ -165,7 +167,7 @@ func nopHealthcheck(context.Context, *Container) error {
 
 // InitFunc defines a function to be called on a ready to use container to set
 // up its initial state before running the tests. For example, InitFunc can
-// take care of creating a SQL table and inserting test data into it
+// take care of creating a SQL table and inserting test data into it.
 type InitFunc func(context.Context, *Container) error
 
 func nopInit(context.Context, *Container) error {
@@ -174,7 +176,7 @@ func nopInit(context.Context, *Container) error {
 
 // Options includes Gnomock startup configuration. Functional options
 // (WithSomething) should be used instead of directly initializing objects of
-// this type whenever possible
+// this type whenever possible.
 type Options struct {
 	// Timeout is an amount of time to wait before considering Start operation
 	// as failed.

--- a/parallel.go
+++ b/parallel.go
@@ -4,7 +4,7 @@ import "golang.org/x/sync/errgroup"
 
 // InParallel begins parallel preset execution setup. Use Start to add more
 // presets with their configuration to parallel execution, and Go() in the end
-// to kick-off everything
+// to kick-off everything.
 func InParallel() *Parallel {
 	return &Parallel{}
 }
@@ -15,13 +15,13 @@ type configuredPreset struct {
 	opts []Option
 }
 
-// Parallel is a builder object that configures parallel preset execution
+// Parallel is a builder object that configures parallel preset execution.
 type Parallel struct {
 	presets []configuredPreset
 }
 
 // Start adds the provided preset with its configuration to the parallel
-// execution kicked-off by Go(), together with other added presets
+// execution kicked-off by Go(), together with other added presets.
 func (b *Parallel) Start(p Preset, opts ...Option) *Parallel {
 	b.presets = append(b.presets, configuredPreset{p, opts})
 
@@ -32,7 +32,7 @@ func (b *Parallel) Start(p Preset, opts ...Option) *Parallel {
 // order as they were added with Start. An error is returned if any of the
 // containers failed to start and become available. Even if Go() returns an
 // errors, there still might be containers created in the process, and it is
-// callers responsibility to Stop them
+// callers responsibility to Stop them.
 func (b *Parallel) Go() ([]*Container, error) {
 	var g errgroup.Group
 

--- a/ports.go
+++ b/ports.go
@@ -4,17 +4,17 @@ import "errors"
 
 // DefaultPort should be used with simple containers that expose only one TCP
 // port. Use DefaultTCP function when creating a container, and use DefaultPort
-// when calling Address()
+// when calling Address().
 const DefaultPort = "default"
 
 // ErrPortNotFound means that a port with the requested name was not found in
 // the created container. Make sure that the name used in Find method matches
 // the name used in in NamedPorts. For default values, use DefaultTCP and
-// DefaultPort
+// DefaultPort.
 var ErrPortNotFound = errors.New("port not found")
 
 // Port is a combination of port number and protocol that are exposed in a
-// container
+// container.
 type Port struct {
 	// Protocol of the exposed port (TCP/UDP).
 	Protocol string `json:"protocol"`
@@ -29,7 +29,7 @@ type Port struct {
 // DefaultTCP is a utility function to use with simple containers exposing a
 // single TCP port. Use it to create default named port for the provided port
 // number. Pass DefaultPort to Address() method to get the address of the
-// default port
+// default port.
 func DefaultTCP(port int) NamedPorts {
 	return NamedPorts{
 		DefaultPort: Port{Protocol: "tcp", Port: port},
@@ -37,7 +37,7 @@ func DefaultTCP(port int) NamedPorts {
 }
 
 // TCP returns a Port with the provided number and "tcp" protocol. This is a
-// utility function, it is equivalent to creating a Port explicitly
+// utility function, it is equivalent to creating a Port explicitly.
 func TCP(port int) Port {
 	return Port{Protocol: "tcp", Port: port}
 }
@@ -45,18 +45,18 @@ func TCP(port int) Port {
 // NamedPorts is a collection of ports exposed by a container, where every
 // exposed port is given a name. Some examples of names are "web" or "api" for
 // a container that exposes two separate ports: one for web access and another
-// for API calls
+// for API calls.
 type NamedPorts map[string]Port
 
 // Get returns a port with the provided name. An empty value is returned if
-// there are no ports with the given name
+// there are no ports with the given name.
 func (p NamedPorts) Get(name string) Port {
 	return p[name]
 }
 
 // Find returns the name of a port with the provided protocol and number. Use
 // this method to find out the name of an exposed ports, when port number and
-// protocol are known
+// protocol are known.
 func (p NamedPorts) Find(proto string, portNum int) (string, error) {
 	for name, port := range p {
 		if proto == port.Protocol && portNum == port.Port {

--- a/preset/cockroachdb/preset.go
+++ b/preset/cockroachdb/preset.go
@@ -21,9 +21,11 @@ import (
 	"github.com/orlangure/gnomock/internal/registry"
 )
 
-const defaultVersion = "v20.1.10"
-const defaultPort = 26257
-const defaultDatabase = "mydb"
+const (
+	defaultVersion  = "v20.1.10"
+	defaultPort     = 26257
+	defaultDatabase = "mydb"
+)
 
 func init() {
 	registry.Register("cockroachdb", func() gnomock.Preset { return &P{} })
@@ -139,6 +141,7 @@ func (p *P) initf() gnomock.InitFunc {
 		return nil
 	}
 }
+
 func connect(c *gnomock.Container, db string) (*sql.DB, error) {
 	connStr := fmt.Sprintf(
 		"host=%s port=%d sslmode=disable user=root dbname=%s",

--- a/preset/elastic/preset.go
+++ b/preset/elastic/preset.go
@@ -17,8 +17,10 @@ import (
 	"github.com/orlangure/gnomock/internal/registry"
 )
 
-const defaultVersion = "7.9.3"
-const defaultPort = 9200
+const (
+	defaultVersion = "7.9.3"
+	defaultPort    = 9200
+)
 
 func init() {
 	registry.Register("elastic", func() gnomock.Preset { return &P{} })

--- a/preset/k3s/options.go
+++ b/preset/k3s/options.go
@@ -1,7 +1,7 @@
 package k3s
 
 // Option is an optional configuration of this Gnomock preset. Use available
-// Options to configure the container
+// Options to configure the container.
 type Option func(*P)
 
 // WithVersion sets image version.

--- a/preset/k3s/preset.go
+++ b/preset/k3s/preset.go
@@ -36,15 +36,19 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-const defaultPort = 48443
-const defaultVersion = "latest"
-const defaultHostname = "localhost"
+const (
+	defaultPort     = 48443
+	defaultVersion  = "latest"
+	defaultHostname = "localhost"
+)
 
 // KubeconfigPort is a port that exposes a single `/kubeconfig` endpoint. It
 // can be used to retrieve a configured kubeconfig file to use to connect to
 // this container using kubectl.
-const KubeconfigPort = "kubeconfig"
-const kubeconfigPort = 80
+const (
+	KubeconfigPort = "kubeconfig"
+	kubeconfigPort = 80
+)
 
 func init() {
 	registry.Register("kubernetes", func() gnomock.Preset { return &P{} })

--- a/preset/k3s/preset_test.go
+++ b/preset/k3s/preset_test.go
@@ -90,3 +90,36 @@ func TestPreset_withDefaults(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, pods.Items)
 }
+
+func TestConfigBytes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("fails on wrong url", func(t *testing.T) {
+		p := k3s.Preset()
+		c := &gnomock.Container{
+			Host:  "1%%2",
+			Ports: p.Ports(),
+		}
+
+		bs, err := k3s.ConfigBytes(c)
+		require.Nil(t, bs)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid URL")
+	})
+
+	t.Run("fails on wrong port", func(t *testing.T) {
+		ports := gnomock.NamedPorts{
+			k3s.KubeconfigPort: gnomock.TCP(1),
+		}
+
+		c := &gnomock.Container{
+			Host:  "127.0.0.1",
+			Ports: ports,
+		}
+
+		bs, err := k3s.ConfigBytes(c)
+		require.Nil(t, bs)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "connection refused")
+	})
+}

--- a/preset/kafka/preset.go
+++ b/preset/kafka/preset.go
@@ -15,17 +15,19 @@ import (
 	"github.com/segmentio/kafka-go"
 )
 
-// The following ports are exposed by this preset:
+// The following ports are exposed by this preset:.
 const (
 	BrokerPort    = "broker"
 	ZooKeeperPort = "zookeeper"
 	WebPort       = "web"
 )
 
-const defaultVersion = "2.5.1-L0"
-const brokerPort = 49092
-const zookeeperPort = 2181
-const webPort = 3030
+const (
+	defaultVersion = "2.5.1-L0"
+	brokerPort     = 49092
+	zookeeperPort  = 2181
+	webPort        = 3030
+)
 
 // Message is a single message sent to Kafka.
 type Message struct {

--- a/preset/localstack/options.go
+++ b/preset/localstack/options.go
@@ -6,13 +6,13 @@ import (
 )
 
 // Option is an optional configuration of this Gnomock preset. Use available
-// Options to configure the container
+// Options to configure the container.
 type Option func(*P)
 
-// Service represents an AWS service that can be setup using localstack
+// Service represents an AWS service that can be setup using localstack.
 type Service string
 
-// UnmarshalJSON allows to unmarshal string into Service type
+// UnmarshalJSON allows to unmarshal string into Service type.
 func (s *Service) UnmarshalJSON(bs []byte) error {
 	var service string
 
@@ -53,7 +53,7 @@ func (s *Service) UnmarshalJSON(bs []byte) error {
 	}
 }
 
-// These services are available in this Preset
+// These services are available in this Preset.
 const (
 	APIGateway       Service = "apigateway"
 	CloudFormation   Service = "cloudformation"
@@ -82,7 +82,7 @@ const (
 )
 
 // WithServices selects localstack services to spin up. It is OK to not select
-// any services, but in such case the container will be useless
+// any services, but in such case the container will be useless.
 func WithServices(services ...Service) Option {
 	return func(o *P) {
 		o.Services = append(o.Services, services...)

--- a/preset/localstack/options_s3.go
+++ b/preset/localstack/options_s3.go
@@ -94,8 +94,7 @@ func (p *P) createBuckets(svc *s3.S3) ([]string, error) {
 func (p *P) createBucket(svc *s3.S3, bucket string) error {
 	input := &s3.CreateBucketInput{Bucket: aws.String(bucket)}
 
-	_, err := svc.CreateBucket(input)
-	if err != nil {
+	if _, err := svc.CreateBucket(input); err != nil {
 		return fmt.Errorf("can't create bucket '%s': %w", bucket, err)
 	}
 

--- a/preset/localstack/options_s3.go
+++ b/preset/localstack/options_s3.go
@@ -24,7 +24,7 @@ import (
 // this bucket.
 //
 // This function does nothing if you don't provide localstack.S3 as one of the
-// services in WithServices
+// services in WithServices.
 func WithS3Files(path string) Option {
 	return func(p *P) {
 		p.S3Path = path

--- a/preset/localstack/preset.go
+++ b/preset/localstack/preset.go
@@ -94,7 +94,12 @@ func (p *P) healthcheck(services []string) gnomock.HealthcheckFunc {
 	return func(ctx context.Context, c *gnomock.Container) (err error) {
 		addr := p.healthCheckAddress(c)
 
-		res, err := http.Get(addr) //nolint:gosec
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, addr, nil)
+		if err != nil {
+			return err
+		}
+
+		res, err := http.DefaultClient.Do(req)
 		if err != nil {
 			return err
 		}

--- a/preset/localstack/preset.go
+++ b/preset/localstack/preset.go
@@ -18,7 +18,7 @@ import (
 const (
 	webPort = "web"
 
-	// APIPort should be used to configure AWS SDK endpoint
+	// APIPort should be used to configure AWS SDK endpoint.
 	APIPort = "api"
 )
 
@@ -33,7 +33,7 @@ func init() {
 // provide any services using WithServices options, but in such case a new
 // localstack container will be useless.
 //
-// This Preset cannot be used with localstack image prior to 0.11.0
+// This Preset cannot be used with localstack image prior to 0.11.0.
 func Preset(opts ...Option) gnomock.Preset {
 	p := &P{}
 
@@ -44,19 +44,19 @@ func Preset(opts ...Option) gnomock.Preset {
 	return p
 }
 
-// P is a Gnomock Preset localstack implementation
+// P is a Gnomock Preset localstack implementation.
 type P struct {
 	Services []Service `json:"services"`
 	S3Path   string    `json:"s3_path"`
 	Version  string    `json:"version"`
 }
 
-// Image returns an image that should be pulled to create this container
+// Image returns an image that should be pulled to create this container.
 func (p *P) Image() string {
 	return fmt.Sprintf("docker.io/localstack/localstack:%s", p.Version)
 }
 
-// Ports returns ports that should be used to access this container
+// Ports returns ports that should be used to access this container.
 func (p *P) Ports() gnomock.NamedPorts {
 	return gnomock.NamedPorts{
 		webPort: {Protocol: "tcp", Port: 8080},
@@ -64,7 +64,7 @@ func (p *P) Ports() gnomock.NamedPorts {
 	}
 }
 
-// Options returns a list of options to configure this container
+// Options returns a list of options to configure this container.
 func (p *P) Options() []gnomock.Option {
 	p.setDefaults()
 

--- a/preset/mariadb/options.go
+++ b/preset/mariadb/options.go
@@ -1,11 +1,11 @@
 package mariadb
 
 // Option is an optional configuration of this Gnomock preset. Use available
-// Options to configure the container
+// Options to configure the container.
 type Option func(*P)
 
 // WithUser creates a new superuser with the provided credentials in the
-// container. If not used, the default credentials are gnomock:gnoria
+// container. If not used, the default credentials are gnomock:gnoria.
 func WithUser(user, password string) Option {
 	return func(p *P) {
 		p.User = user
@@ -15,7 +15,7 @@ func WithUser(user, password string) Option {
 
 // WithDatabase creates a database with the provided name in the container. If
 // not provided, "mydb" is used by default.  WithQueries, if provided, runs
-// against the new database
+// against the new database.
 func WithDatabase(db string) Option {
 	return func(p *P) {
 		p.DB = db
@@ -23,7 +23,7 @@ func WithDatabase(db string) Option {
 }
 
 // WithQueries executes the provided queries against the database created with
-// WithDatabase, or against default "mydb" database
+// WithDatabase, or against default "mydb" database.
 func WithQueries(queries ...string) Option {
 	return func(p *P) {
 		p.Queries = append(p.Queries, queries...)
@@ -31,7 +31,7 @@ func WithQueries(queries ...string) Option {
 }
 
 // WithQueriesFile sets a file name to read initial queries from. Queries from
-// this file are executed before any other queries provided in WithQueries
+// this file are executed before any other queries provided in WithQueries.
 func WithQueriesFile(file string) Option {
 	return func(p *P) {
 		p.QueriesFiles = append(p.QueriesFiles, file)

--- a/preset/mariadb/preset.go
+++ b/preset/mariadb/preset.go
@@ -14,11 +14,13 @@ import (
 	"github.com/orlangure/gnomock/internal/registry"
 )
 
-const defaultUser = "gnomock"
-const defaultPassword = "gnoria"
-const defaultDatabase = "mydb"
-const defaultPort = 3306
-const defaultVersion = "10.5.8"
+const (
+	defaultUser     = "gnomock"
+	defaultPassword = "gnoria"
+	defaultDatabase = "mydb"
+	defaultPort     = 3306
+	defaultVersion  = "10.5.8"
+)
 
 var setLoggerOnce sync.Once
 
@@ -42,7 +44,7 @@ func Preset(opts ...Option) gnomock.Preset {
 	return p
 }
 
-// P is a Gnomock Preset implementation of MariaDB database
+// P is a Gnomock Preset implementation of MariaDB database.
 type P struct {
 	DB           string   `json:"db"`
 	User         string   `json:"user"`
@@ -52,17 +54,17 @@ type P struct {
 	Version      string   `json:"version"`
 }
 
-// Image returns an image that should be pulled to create this container
+// Image returns an image that should be pulled to create this container.
 func (p *P) Image() string {
 	return fmt.Sprintf("docker.io/library/mariadb:%s", p.Version)
 }
 
-// Ports returns ports that should be used to access this container
+// Ports returns ports that should be used to access this container.
 func (p *P) Ports() gnomock.NamedPorts {
 	return gnomock.DefaultTCP(defaultPort)
 }
 
-// Options returns a list of options to configure this container
+// Options returns a list of options to configure this container.
 func (p *P) Options() []gnomock.Option {
 	setLoggerOnce.Do(func() {
 		// err is always nil for non-nil logger

--- a/preset/memcached/options.go
+++ b/preset/memcached/options.go
@@ -1,7 +1,7 @@
 package memcached
 
 // Option is an optional configuration of this Gnomock preset. Use available
-// Options to configure the container
+// Options to configure the container.
 type Option func(*P)
 
 // WithValues initializes Memcached with the provided key/value pairs. These values

--- a/preset/memcached/preset.go
+++ b/preset/memcached/preset.go
@@ -20,7 +20,7 @@ func init() {
 
 // Preset creates a new Gmomock Memcached preset. This preset includes a Memcached
 // specific healthcheck function, default Memcached image and port, and allows to
-// optionally set up initial state
+// optionally set up initial state.
 func Preset(opts ...Option) gnomock.Preset {
 	p := &P{}
 
@@ -31,24 +31,24 @@ func Preset(opts ...Option) gnomock.Preset {
 	return p
 }
 
-// P is a Gnomock Preset implementation for Memcached storage
+// P is a Gnomock Preset implementation for Memcached storage.
 type P struct {
 	Values     map[string]string `json:"values"`
 	ByteValues map[string][]byte `json:"byteValues"`
 	Version    string            `json:"version"`
 }
 
-// Image returns an image that should be pulled to create this container
+// Image returns an image that should be pulled to create this container.
 func (p *P) Image() string {
 	return fmt.Sprintf("docker.io/library/memcached:%s", p.Version)
 }
 
-// Ports returns ports that should be used to access this container
+// Ports returns ports that should be used to access this container.
 func (p *P) Ports() gnomock.NamedPorts {
 	return gnomock.DefaultTCP(11211)
 }
 
-// Options returns a list of options to configure this container
+// Options returns a list of options to configure this container.
 func (p *P) Options() []gnomock.Option {
 	p.setDefaults()
 

--- a/preset/mongo/options.go
+++ b/preset/mongo/options.go
@@ -1,7 +1,7 @@
 package mongo
 
 // Option is an optional configuration of this Gnomock preset. Use available
-// Options to configure the container
+// Options to configure the container.
 type Option func(*P)
 
 // WithData sets up initial container state according to the directory
@@ -23,7 +23,7 @@ type Option func(*P)
 //
 // Top level files under "path" are ignored, only directories are used.
 // Similarly, directories located anywhere besides top-level "path", are also
-// ignored
+// ignored.
 func WithData(path string) Option {
 	return func(p *P) {
 		p.DataPath = path
@@ -33,7 +33,7 @@ func WithData(path string) Option {
 // WithUser creates a root user with the provided name and password. This user
 // should be used as a part of mongodb connection string. If you choose not to
 // use your own user and password, the databases will be unprotected, and you
-// won't need to specify any name and password in your connection string
+// won't need to specify any name and password in your connection string.
 func WithUser(user, pass string) Option {
 	return func(p *P) {
 		p.User = user

--- a/preset/mongo/preset.go
+++ b/preset/mongo/preset.go
@@ -42,7 +42,7 @@ func Preset(opts ...Option) gnomock.Preset {
 	return p
 }
 
-// P is a Gnomock Preset implementation of MongoDB
+// P is a Gnomock Preset implementation of MongoDB.
 type P struct {
 	DataPath string `json:"data_path"`
 	User     string `json:"user"`
@@ -50,17 +50,17 @@ type P struct {
 	Version  string `json:"version"`
 }
 
-// Image returns an image that should be pulled to create this container
+// Image returns an image that should be pulled to create this container.
 func (p *P) Image() string {
 	return fmt.Sprintf("docker.io/library/mongo:%s", p.Version)
 }
 
-// Ports returns ports that should be used to access this container
+// Ports returns ports that should be used to access this container.
 func (p *P) Ports() gnomock.NamedPorts {
 	return gnomock.DefaultTCP(27017)
 }
 
-// Options returns a list of options to configure this container
+// Options returns a list of options to configure this container.
 func (p *P) Options() []gnomock.Option {
 	p.setDefaults()
 

--- a/preset/mssql/options.go
+++ b/preset/mssql/options.go
@@ -1,11 +1,11 @@
 package mssql
 
 // Option is an optional configuration of this Gnomock preset. Use available
-// Options to configure the container
+// Options to configure the container.
 type Option func(*P)
 
 // WithAdminPassword sets administrator password that can be used to connect
-// (default: Gn0m!ck~)
+// (default: Gn0m!ck~).
 func WithAdminPassword(password string) Option {
 	return func(o *P) {
 		o.Password = password
@@ -14,7 +14,7 @@ func WithAdminPassword(password string) Option {
 
 // WithDatabase creates a database with the provided name in the container. If
 // not provided, "mydb" is used by default.  WithQueries, if provided, runs
-// against the new database
+// against the new database.
 func WithDatabase(db string) Option {
 	return func(o *P) {
 		o.DB = db
@@ -22,7 +22,7 @@ func WithDatabase(db string) Option {
 }
 
 // WithQueries executes the provided queries against the database created with
-// WithDatabase, or against default "mydb" database
+// WithDatabase, or against default "mydb" database.
 func WithQueries(queries ...string) Option {
 	return func(o *P) {
 		o.Queries = append(o.Queries, queries...)
@@ -31,7 +31,7 @@ func WithQueries(queries ...string) Option {
 
 // WithLicense sets EULA acceptance state. To accept the license, use true. See
 // https://hub.docker.com/_/microsoft-mssql-server?tab=description for more
-// information
+// information.
 func WithLicense(accept bool) Option {
 	return func(o *P) {
 		o.License = accept
@@ -39,7 +39,7 @@ func WithLicense(accept bool) Option {
 }
 
 // WithQueriesFile sets a file name to read initial queries from. Queries from
-// this file are executed before any other queries provided in WithQueries
+// this file are executed before any other queries provided in WithQueries.
 func WithQueriesFile(file string) Option {
 	return func(p *P) {
 		p.QueriesFiles = append(p.QueriesFiles, file)

--- a/preset/mssql/preset.go
+++ b/preset/mssql/preset.go
@@ -12,11 +12,13 @@ import (
 	"github.com/orlangure/gnomock/internal/registry"
 )
 
-const masterDB = "master"
-const defaultPassword = "Gn0m!ck~"
-const defaultDatabase = "mydb"
-const defaultPort = 1433
-const defaultVersion = "2019-latest"
+const (
+	masterDB        = "master"
+	defaultPassword = "Gn0m!ck~"
+	defaultDatabase = "mydb"
+	defaultPort     = 1433
+	defaultVersion  = "2019-latest"
+)
 
 func init() {
 	registry.Register("mssql", func() gnomock.Preset { return &P{} })
@@ -39,7 +41,7 @@ func Preset(opts ...Option) gnomock.Preset {
 	return p
 }
 
-// P is a Gnomock Preset implementation of Microsoft SQL Server database
+// P is a Gnomock Preset implementation of Microsoft SQL Server database.
 type P struct {
 	DB           string   `json:"db"`
 	Password     string   `json:"password"`
@@ -49,17 +51,17 @@ type P struct {
 	Version      string   `json:"version"`
 }
 
-// Image returns an image that should be pulled to create this container
+// Image returns an image that should be pulled to create this container.
 func (p *P) Image() string {
 	return fmt.Sprintf("mcr.microsoft.com/mssql/server:%s", p.Version)
 }
 
-// Ports returns ports that should be used to access this container
+// Ports returns ports that should be used to access this container.
 func (p *P) Ports() gnomock.NamedPorts {
 	return gnomock.DefaultTCP(defaultPort)
 }
 
-// Options returns a list of options to configure this container
+// Options returns a list of options to configure this container.
 func (p *P) Options() []gnomock.Option {
 	p.setDefaults()
 

--- a/preset/mysql/options.go
+++ b/preset/mysql/options.go
@@ -1,11 +1,11 @@
 package mysql
 
 // Option is an optional configuration of this Gnomock preset. Use available
-// Options to configure the container
+// Options to configure the container.
 type Option func(*P)
 
 // WithUser creates a new superuser with the provided credentials in the
-// container. If not used, the default credentials are gnomock:gnomick
+// container. If not used, the default credentials are gnomock:gnomick.
 func WithUser(user, password string) Option {
 	return func(p *P) {
 		p.User = user
@@ -15,7 +15,7 @@ func WithUser(user, password string) Option {
 
 // WithDatabase creates a database with the provided name in the container. If
 // not provided, "mydb" is used by default.  WithQueries, if provided, runs
-// against the new database
+// against the new database.
 func WithDatabase(db string) Option {
 	return func(p *P) {
 		p.DB = db
@@ -23,7 +23,7 @@ func WithDatabase(db string) Option {
 }
 
 // WithQueries executes the provided queries against the database created with
-// WithDatabase, or against default "mydb" database
+// WithDatabase, or against default "mydb" database.
 func WithQueries(queries ...string) Option {
 	return func(p *P) {
 		p.Queries = append(p.Queries, queries...)
@@ -31,7 +31,7 @@ func WithQueries(queries ...string) Option {
 }
 
 // WithQueriesFile sets a file name to read initial queries from. Queries from
-// this file are executed before any other queries provided in WithQueries
+// this file are executed before any other queries provided in WithQueries.
 func WithQueriesFile(file string) Option {
 	return func(p *P) {
 		p.QueriesFiles = append(p.QueriesFiles, file)

--- a/preset/mysql/preset.go
+++ b/preset/mysql/preset.go
@@ -14,11 +14,13 @@ import (
 	"github.com/orlangure/gnomock/internal/registry"
 )
 
-const defaultUser = "gnomock"
-const defaultPassword = "gnomick"
-const defaultDatabase = "mydb"
-const defaultPort = 3306
-const defaultVersion = "8.0.22"
+const (
+	defaultUser     = "gnomock"
+	defaultPassword = "gnomick"
+	defaultDatabase = "mydb"
+	defaultPort     = 3306
+	defaultVersion  = "8.0.22"
+)
 
 var setLoggerOnce sync.Once
 
@@ -42,7 +44,7 @@ func Preset(opts ...Option) gnomock.Preset {
 	return p
 }
 
-// P is a Gnomock Preset implementation of MySQL database
+// P is a Gnomock Preset implementation of MySQL database.
 type P struct {
 	DB           string   `json:"db"`
 	User         string   `json:"user"`
@@ -52,17 +54,17 @@ type P struct {
 	Version      string   `json:"version"`
 }
 
-// Image returns an image that should be pulled to create this container
+// Image returns an image that should be pulled to create this container.
 func (p *P) Image() string {
 	return fmt.Sprintf("docker.io/library/mysql:%s", p.Version)
 }
 
-// Ports returns ports that should be used to access this container
+// Ports returns ports that should be used to access this container.
 func (p *P) Ports() gnomock.NamedPorts {
 	return gnomock.DefaultTCP(defaultPort)
 }
 
-// Options returns a list of options to configure this container
+// Options returns a list of options to configure this container.
 func (p *P) Options() []gnomock.Option {
 	setLoggerOnce.Do(func() {
 		// err is always nil for non-nil logger

--- a/preset/postgres/preset.go
+++ b/preset/postgres/preset.go
@@ -12,12 +12,14 @@ import (
 	"github.com/orlangure/gnomock/internal/registry"
 )
 
-const defaultUser = "postgres"
-const defaultPassword = "password"
-const defaultDatabase = "postgres"
-const defaultSSLMode = "disable"
-const defaultPort = 5432
-const defaultVersion = "12.5"
+const (
+	defaultUser     = "postgres"
+	defaultPassword = "password"
+	defaultDatabase = "postgres"
+	defaultSSLMode  = "disable"
+	defaultPort     = 5432
+	defaultVersion  = "12.5"
+)
 
 func init() {
 	registry.Register("postgres", func() gnomock.Preset { return &P{} })
@@ -39,7 +41,7 @@ func Preset(opts ...Option) gnomock.Preset {
 	return p
 }
 
-// P is a Gnomock Preset implementation of PostgreSQL database
+// P is a Gnomock Preset implementation of PostgreSQL database.
 type P struct {
 	DB           string   `json:"db"`
 	Queries      []string `json:"queries"`
@@ -49,17 +51,17 @@ type P struct {
 	Version      string   `json:"version"`
 }
 
-// Image returns an image that should be pulled to create this container
+// Image returns an image that should be pulled to create this container.
 func (p *P) Image() string {
 	return fmt.Sprintf("docker.io/library/postgres:%s", p.Version)
 }
 
-// Ports returns ports that should be used to access this container
+// Ports returns ports that should be used to access this container.
 func (p *P) Ports() gnomock.NamedPorts {
 	return gnomock.DefaultTCP(defaultPort)
 }
 
-// Options returns a list of options to configure this container
+// Options returns a list of options to configure this container.
 func (p *P) Options() []gnomock.Option {
 	p.setDefaults()
 

--- a/preset/rabbitmq/preset.go
+++ b/preset/rabbitmq/preset.go
@@ -21,11 +21,13 @@ import (
 // image is used. See `Preset` docs for more info.
 const ManagementPort = "management"
 
-const defaultUser = "guest"
-const defaultPassword = "guest"
-const defaultVersion = "3.8.9"
-const defaultPort = 5672
-const managementPort = 15672
+const (
+	defaultUser     = "guest"
+	defaultPassword = "guest"
+	defaultVersion  = "3.8.9"
+	defaultPort     = 5672
+	managementPort  = 15672
+)
 
 // Message is a single message sent to RabbitMQ.
 type Message struct {

--- a/preset/rabbitmq/preset_test.go
+++ b/preset/rabbitmq/preset_test.go
@@ -1,8 +1,10 @@
 package rabbitmq_test
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"testing"
 
 	"github.com/orlangure/gnomock"
@@ -180,4 +182,17 @@ func TestPreset_withDefaults(t *testing.T) {
 	ch, err := conn.Channel()
 	require.NoError(t, err)
 	require.NoError(t, ch.Close())
+}
+
+func TestPreset_missingFiles(t *testing.T) {
+	t.Parallel()
+
+	p := rabbitmq.Preset(rabbitmq.WithMessagesFile("missing-file"))
+	container, err := gnomock.Start(p)
+
+	require.Error(t, err)
+	require.Nil(t, container)
+
+	pathErr := &os.PathError{}
+	require.True(t, errors.As(err, &pathErr))
 }

--- a/preset/redis/options.go
+++ b/preset/redis/options.go
@@ -1,12 +1,12 @@
 package redis
 
 // Option is an optional configuration of this Gnomock preset. Use available
-// Options to configure the container
+// Options to configure the container.
 type Option func(*P)
 
 // WithValues initializes Redis with the provided key/value pairs. These values
 // never expire. See go-redis/redis package for information on supported value
-// types
+// types.
 func WithValues(vs map[string]interface{}) Option {
 	return func(p *P) {
 		p.Values = vs

--- a/preset/redis/preset.go
+++ b/preset/redis/preset.go
@@ -20,7 +20,7 @@ func init() {
 
 // Preset creates a new Gmomock Redis preset. This preset includes a Redis
 // specific healthcheck function, default Redis image and port, and allows to
-// optionally set up initial state
+// optionally set up initial state.
 func Preset(opts ...Option) gnomock.Preset {
 	p := &P{}
 
@@ -31,23 +31,23 @@ func Preset(opts ...Option) gnomock.Preset {
 	return p
 }
 
-// P is a Gnomock Preset implementation for Redis storage
+// P is a Gnomock Preset implementation for Redis storage.
 type P struct {
 	Values  map[string]interface{} `json:"values"`
 	Version string                 `json:"version"`
 }
 
-// Image returns an image that should be pulled to create this container
+// Image returns an image that should be pulled to create this container.
 func (p *P) Image() string {
 	return fmt.Sprintf("docker.io/library/redis:%s", p.Version)
 }
 
-// Ports returns ports that should be used to access this container
+// Ports returns ports that should be used to access this container.
 func (p *P) Ports() gnomock.NamedPorts {
 	return gnomock.DefaultTCP(6379)
 }
 
-// Options returns a list of options to configure this container
+// Options returns a list of options to configure this container.
 func (p *P) Options() []gnomock.Option {
 	p.setDefaults()
 

--- a/preset/splunk/options.go
+++ b/preset/splunk/options.go
@@ -1,7 +1,7 @@
 package splunk
 
 // Option is an optional configuration of this Gnomock preset. Use available
-// Options to configure the container
+// Options to configure the container.
 type Option func(*P)
 
 // WithVersion sets splunk version (see
@@ -12,7 +12,7 @@ func WithVersion(version string) Option {
 	}
 }
 
-// WithValues initializes Splunk with the provided values as log entries
+// WithValues initializes Splunk with the provided values as log entries.
 func WithValues(vs []Event) Option {
 	return func(p *P) {
 		p.Values = vs
@@ -21,7 +21,7 @@ func WithValues(vs []Event) Option {
 
 // WithValuesFile sets file name to use as a source of initial events to
 // ingest. These events are ingested first, followed by any other events sent
-// using WithValues
+// using WithValues.
 func WithValuesFile(file string) Option {
 	return func(p *P) {
 		p.ValuesFile = file
@@ -30,7 +30,7 @@ func WithValuesFile(file string) Option {
 
 // WithLicense lets the user choose to accept Splunk enterprise license
 // (see more at https://hub.docker.com/_/splunk-enterprise). Failure to accept
-// the license will prevent Splunk container from starting
+// the license will prevent Splunk container from starting.
 func WithLicense(accept bool) Option {
 	return func(o *P) {
 		o.AcceptLicense = accept

--- a/preset/splunk/preset.go
+++ b/preset/splunk/preset.go
@@ -19,13 +19,13 @@ import (
 )
 
 const (
-	// CollectorPort is the name of a port exposed by Splunk Collector
+	// CollectorPort is the name of a port exposed by Splunk Collector.
 	CollectorPort string = "collector"
 
-	// APIPort is the name of a port exposed by Splunk API
+	// APIPort is the name of a port exposed by Splunk API.
 	APIPort string = "api"
 
-	// WebPort is the name of a port exposed by Splunk web UI
+	// WebPort is the name of a port exposed by Splunk web UI.
 	WebPort string = "web"
 )
 
@@ -37,7 +37,7 @@ func init() {
 
 // Preset creates a new Gnomock Splunk preset. This preset includes a Splunk
 // specific healthcheck function, default Splunk image and ports, and allows to
-// optionally ingest initial logs
+// optionally ingest initial logs.
 func Preset(opts ...Option) gnomock.Preset {
 	p := &P{}
 
@@ -48,7 +48,7 @@ func Preset(opts ...Option) gnomock.Preset {
 	return p
 }
 
-// P is a Gnomock Preset implementation of Splunk
+// P is a Gnomock Preset implementation of Splunk.
 type P struct {
 	Values        []Event `json:"values"`
 	ValuesFile    string  `json:"values_file"`
@@ -57,12 +57,12 @@ type P struct {
 	Version       string  `json:"version"`
 }
 
-// Image returns an image that should be pulled to create this container
+// Image returns an image that should be pulled to create this container.
 func (p *P) Image() string {
 	return fmt.Sprintf("docker.io/splunk/splunk:%s", p.Version)
 }
 
-// Ports returns ports that should be used to access this container
+// Ports returns ports that should be used to access this container.
 func (p *P) Ports() gnomock.NamedPorts {
 	return gnomock.NamedPorts{
 		CollectorPort: gnomock.TCP(8088),
@@ -71,7 +71,7 @@ func (p *P) Ports() gnomock.NamedPorts {
 	}
 }
 
-// Options returns a list of options to configure this container
+// Options returns a list of options to configure this container.
 func (p *P) Options() []gnomock.Option {
 	p.setDefaults()
 

--- a/preset/splunk/preset.go
+++ b/preset/splunk/preset.go
@@ -3,7 +3,7 @@
 // create a configured Splunk container to use in tests.
 //
 // Splunk image is relatively heavy (larger than 1.5GB), and its startup time
-// is longer than usual. Using this container may make the tests much longer
+// is longer than usual. Using this container may make the tests much longer.
 package splunk
 
 import (
@@ -103,12 +103,12 @@ func (p *P) setDefaults() {
 
 func healthcheck(password string) gnomock.HealthcheckFunc {
 	return func(ctx context.Context, c *gnomock.Container) (err error) {
-		err = checkAPI(c, password)
+		err = checkAPI(ctx, c, password)
 		if err != nil {
 			return err
 		}
 
-		err = checkHEC(c)
+		err = checkHEC(ctx, c)
 		if err != nil {
 			return err
 		}
@@ -117,8 +117,8 @@ func healthcheck(password string) gnomock.HealthcheckFunc {
 	}
 }
 
-func checkAPI(c *gnomock.Container, password string) error {
-	post := requestWithPassword(http.MethodPost, password, false)
+func checkAPI(ctx context.Context, c *gnomock.Container, password string) error {
+	post := requestWithAuth(ctx, http.MethodPost, password, false)
 	uri := fmt.Sprintf("https://%s/services/auth/login", c.Address(APIPort))
 
 	data := url.Values{}
@@ -132,8 +132,8 @@ func checkAPI(c *gnomock.Container, password string) error {
 	return err
 }
 
-func checkHEC(c *gnomock.Container) error {
-	get := requestWithPassword(http.MethodGet, "", false)
+func checkHEC(ctx context.Context, c *gnomock.Container) error {
+	get := requestWithAuth(ctx, http.MethodGet, "", false)
 	uri := fmt.Sprintf("https://%s/services/collector/health", c.Address(CollectorPort))
 
 	_, err := get(uri, bytes.NewBufferString(""))


### PR DESCRIPTION
This PR updates golangci-lint version and adds a few recently added linters.
Of course lint started to fail, so I had to fix the issues by refactoring some of the packages.