### PR TITLE
Support external DOCKER_HOST

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,11 @@ Gnomock can be used in two different ways:
 - Imported directly as a package in any **Go** project
 - Accessed over HTTP running as a daemon in **any other language**
 
-⚠️ Both ways **require** an active Docker daemon running locally in
-the same environment.
+Both ways **require** an active Docker daemon running **locally** in the same
+environment.
+
+External `DOCKER_HOST` support is experimental. It cannot be reliably tested at
+this moment, but it might work.
 
 ### Using Gnomock in Go applications
 

--- a/preset_test.go
+++ b/preset_test.go
@@ -54,7 +54,7 @@ func TestPreset_containerRemainsIfDebug(t *testing.T) {
 	p := &testutil.TestPreset{Img: testutil.TestImage}
 	container, err := gnomock.Start(
 		p,
-		gnomock.WithTimeout(time.Second*10),
+		gnomock.WithTimeout(time.Second*15),
 		gnomock.WithDebugMode(),
 		gnomock.WithHealthCheck(failingHealthcheck),
 	)

--- a/sdktest/python/test/test_sdk.py
+++ b/sdktest/python/test/test_sdk.py
@@ -1,12 +1,24 @@
 import gnomock
 from gnomock.rest import ApiException
+from urllib.parse import urlparse
+import os
 
 import unittest
 import os
 
 class TestSDK(unittest.TestCase):
     def setUp(self):
-        with gnomock.ApiClient() as client:
+        addr = "127.0.0.1"
+
+        dh = os.environ.get("DOCKER_HOST")
+        if dh:
+            u = urlparse(dh)
+            addr = u.hostname
+
+        host = "http://{}:23042".format(addr)
+
+        configuration = gnomock.Configuration(host=host)
+        with gnomock.ApiClient(configuration) as client:
             self.api = gnomock.PresetsApi(client)
 
     def tearDown(self):


### PR DESCRIPTION
DOCKER_HOST support is experimental and will remain so until there is a
proper way to test this thing reliably. From my manual tests it seems
that it works correctly both for direct usage from Go, and for Gnomock
container usage (external SDKs such as Python)

Fixes #106 