### PR TITLE
Use go 1.16 in CI pipelines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,16 +8,16 @@ commands:
           name: install golang
           command: |
             sudo rm -rf /usr/local/go
-            wget -c https://dl.google.com/go/go1.15.3.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
+            wget -c https://dl.google.com/go/go1.16.3.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
+      - checkout
       - run:
           name: Get dependencies
           command : go get -v -t -d ./...
-      - checkout
 
 jobs:
   lint:
     docker:
-      - image: circleci/golang:1.15
+      - image: circleci/golang:1.16
     steps:
       - checkout
       - run:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,10 +9,10 @@ jobs:
     name: "[core] lint"
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.15
+      - name: Set up Go 1.16
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
       - name: Get dependencies
@@ -28,10 +28,10 @@ jobs:
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
-      - name: Set up Go 1.15
+      - name: Set up Go 1.16
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
       - name: Get dependencies
@@ -92,10 +92,10 @@ jobs:
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
-      - name: Set up Go 1.15
+      - name: Set up Go 1.16
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
       - name: Get dependencies
@@ -115,10 +115,10 @@ jobs:
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
-      - name: Set up Go 1.15
+      - name: Set up Go 1.16
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
       - name: Get dependencies
@@ -138,10 +138,10 @@ jobs:
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
-      - name: Set up Go 1.15
+      - name: Set up Go 1.16
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
       - name: Get dependencies
@@ -161,10 +161,10 @@ jobs:
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
-      - name: Set up Go 1.15
+      - name: Set up Go 1.16
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
       - name: Get dependencies
@@ -184,10 +184,10 @@ jobs:
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
-      - name: Set up Go 1.15
+      - name: Set up Go 1.16
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
       - name: Get dependencies
@@ -207,10 +207,10 @@ jobs:
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
-      - name: Set up Go 1.15
+      - name: Set up Go 1.16
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
       - name: Get dependencies
@@ -230,10 +230,10 @@ jobs:
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
-      - name: Set up Go 1.15
+      - name: Set up Go 1.16
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
       - name: Get dependencies
@@ -253,10 +253,10 @@ jobs:
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
-      - name: Set up Go 1.15
+      - name: Set up Go 1.16
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
       - name: Get dependencies
@@ -276,10 +276,10 @@ jobs:
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
-      - name: Set up Go 1.15
+      - name: Set up Go 1.16
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
       - name: Get dependencies
@@ -299,10 +299,10 @@ jobs:
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
-      - name: Set up Go 1.15
+      - name: Set up Go 1.16
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
       - name: Get dependencies
@@ -322,10 +322,10 @@ jobs:
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
-      - name: Set up Go 1.15
+      - name: Set up Go 1.16
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
       - name: Get dependencies
@@ -345,10 +345,10 @@ jobs:
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
-      - name: Set up Go 1.15
+      - name: Set up Go 1.16
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
       - name: Get dependencies
@@ -368,10 +368,10 @@ jobs:
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
-      - name: Set up Go 1.15
+      - name: Set up Go 1.16
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
       - name: Get dependencies
@@ -391,10 +391,10 @@ jobs:
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
-      - name: Set up Go 1.15
+      - name: Set up Go 1.16
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
       - name: Get dependencies


### PR DESCRIPTION
Package version will remain 1.15 for now. There are dependent packages
that sill use 1.15.