### PR TITLE
Support docker registry auth for private images

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,10 +24,11 @@ jobs:
 
   test-core:
     name: "[core] gnomock, gnomockd"
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+    # strategy:
+    #   matrix:
+    #     os: [ubuntu-latest, macos-latest]
+    # runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,7 +19,6 @@ linters:
     - gofmt
     - gofumpt
     - goimports
-    - golint
     - goprintffuncname
     - gosec
     - gosimple

--- a/docker.go
+++ b/docker.go
@@ -58,10 +58,12 @@ func (g *g) dockerConnect() (*docker, error) {
 	return &docker{client: cli, log: g.log}, nil
 }
 
-func (d *docker) pullImage(ctx context.Context, image string) error {
+func (d *docker) pullImage(ctx context.Context, image string, cfg *Options) error {
 	d.log.Info("pulling image")
 
-	reader, err := d.client.ImagePull(ctx, image, types.ImagePullOptions{})
+	reader, err := d.client.ImagePull(ctx, image, types.ImagePullOptions{
+		RegistryAuth: cfg.Auth,
+	})
 	if err != nil {
 		return fmt.Errorf("can't pull image: %w", err)
 	}
@@ -87,7 +89,7 @@ func (d *docker) pullImage(ctx context.Context, image string) error {
 func (d *docker) startContainer(ctx context.Context, image string, ports NamedPorts, cfg *Options) (*Container, error) {
 	d.log.Info("starting container")
 
-	if err := d.pullImage(ctx, image); err != nil {
+	if err := d.pullImage(ctx, image, cfg); err != nil {
 		return nil, fmt.Errorf("can't pull image: %w", err)
 	}
 

--- a/gnomock_test.go
+++ b/gnomock_test.go
@@ -31,6 +31,7 @@ func TestGnomock_happyFlow(t *testing.T) {
 		gnomock.WithTimeout(time.Minute),
 		gnomock.WithEnv("GNOMOCK_TEST_1=foo"),
 		gnomock.WithEnv("GNOMOCK_TEST_2=bar"),
+		gnomock.WithRegistryAuth(""),
 	)
 
 	require.NoError(t, err)

--- a/options.go
+++ b/options.go
@@ -154,6 +154,21 @@ func WithDisableAutoCleanup() Option {
 	}
 }
 
+// WithRegistryAuth allows to access private docker images. The credentials
+// should be passes as a Base64 encoded string, where the content is a JSON
+// string with two fields: username and password.
+//
+// For Docker Hub, if 2FA authentication is enabled, an access token should be
+// used instead of a password.
+//
+// For example: eyJ1c2VybmFtZSI6ImZvbyIsInBhc3N3b3JkIjoiYmFyIn0K which stands
+// for {"username":"foo","password":"bar"}.
+func WithRegistryAuth(auth string) Option {
+	return func(o *Options) {
+		o.Auth = auth
+	}
+}
+
 // HealthcheckFunc defines a function to be used to determine container health.
 // It receives a host and a port, and returns an error if the container is not
 // ready, or nil when the container can be used. One example of HealthcheckFunc
@@ -208,6 +223,17 @@ type Options struct {
 	// stopped and removed after the tests are complete. By default, Gnomock
 	// will try to stop containers created by it right after the tests exit.
 	DisableAutoCleanup bool `json:"disable_cleanup"`
+
+	// Base64 encoded JSON string with docker access credentials. JSON string
+	// should include two fields: username and password. For Docker Hub, if 2FA
+	// authentication is enabled, an access token should be used instead of a
+	// password.
+	//
+	// For example:
+	//	eyJ1c2VybmFtZSI6ImZvbyIsInBhc3N3b3JkIjoiYmFyIn0K
+	// which stands for
+	//	{"username":"foo","password":"bar"}
+	Auth string `json:"auth"`
 
 	ctx                 context.Context
 	init                InitFunc

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -455,6 +455,14 @@ components:
         disable_cleanup:
           type: boolean
           description: Disables auto removal of this container after tests.
+        auth:
+          type: string
+          description: >
+            base64 encoded JSON string with docker access credentials. JSON
+            string should include two fields, username and password. For Docker
+            Hub, if 2FA authentication is enabled, an access token should be
+            used instead of a password.
+          example: eyJ1c2VybmFtZSI6ImZvbyIsInBhc3N3b3JkIjoiYmFyIn0K
       description: >
         This object includes general Gnomock configuration, similar to all
         presets. Timeout configuration is especially useful for


### PR DESCRIPTION
This commit adds WithRegistryAuth option that allows to access private
docker images, which were not supported before. This feature is not
going to be a part of CI process, but I tested it once with valid and
invalid credentials to access a private docker image, and it looked
good.

There might be a way to "guess" user's credentials as they are likely
stored in ~/.docker/config.json file. On mac, I don't see the creds in
the file, but in Ubuntu it is probably different. For now this should be
good enough for most users.

Closes #188 