### PR TITLE
allow use GNOMOCK_HOST_ADDR env to set docker host address

### DIFF
--- a/container.go
+++ b/container.go
@@ -67,6 +67,10 @@ func isInDocker() bool {
 	return env == "gnomockd"
 }
 
+func customDockerHostAddr() string {
+	return os.Getenv("GNOMOCK_HOST_ADDR")
+}
+
 func generateID(id, sidecar string) string {
 	if len(id) > 10 {
 		id = id[:10]

--- a/gnomock.go
+++ b/gnomock.go
@@ -313,7 +313,9 @@ func envAwareClone(c *Container) *Container {
 	// when gnomock runs inside docker container, the other container is only
 	// accessible through the host
 	if isInDocker() {
-		if isHostDockerInternalAvailable() {
+		if hostAddr := customDockerHostAddr(); hostAddr != "" {
+			containerCopy.Host = hostAddr
+		} else if isHostDockerInternalAvailable() {
 			containerCopy.Host = "host.docker.internal"
 		} else {
 			containerCopy.Host = c.gateway


### PR DESCRIPTION
I use gnomock in the case of docker in docker, the CI (the app to run gnomock) is running in k8s, the `host.docker.internal` is not resolved to host address, gnomock stuck in the health check(mysql) until it timed out.

Finally, I tried to use the ip of docker0 instead of `host.docker.internal` and solved it, I don't know if this is my configuration problem...