### PR TITLE
refactor: move from io/ioutil to io and os package

### DIFF
--- a/cmd/generator/main.go
+++ b/cmd/generator/main.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -331,7 +330,7 @@ func circleci(params presetParams) error {
 //
 // nolint:gosec
 func replacePlaceholder(targetFile, tmplFile, placeholder string, params presetParams) error {
-	targetBs, err := ioutil.ReadFile(targetFile)
+	targetBs, err := os.ReadFile(targetFile)
 	if err != nil {
 		return fmt.Errorf("can't read %s: %w", targetFile, err)
 	}
@@ -350,7 +349,7 @@ func replacePlaceholder(targetFile, tmplFile, placeholder string, params presetP
 
 	targetStr := strings.ReplaceAll(string(targetBs), placeholder, buf.String())
 
-	if err := ioutil.WriteFile(targetFile, []byte(targetStr), 0644); err != nil {
+	if err := os.WriteFile(targetFile, []byte(targetStr), 0644); err != nil {
 		return fmt.Errorf("can't write %s: %w", targetFile, err)
 	}
 

--- a/cmd/generator/templates/gnomockd/preset_test.go.template
+++ b/cmd/generator/templates/gnomockd/preset_test.go.template
@@ -3,9 +3,10 @@ package gnomockd_test
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/orlangure/gnomock"
@@ -18,7 +19,7 @@ func Test{{ .Name }}(t *testing.T) {
 	t.Parallel()
 
 	h := gnomockd.Handler()
-	bs, err := ioutil.ReadFile("./testdata/{{ lower .Name }}.json")
+	bs, err := os.ReadFile("./testdata/{{ lower .Name }}.json")
 	require.NoError(t, err)
 
 	buf := bytes.NewBuffer(bs)
@@ -29,7 +30,7 @@ func Test{{ .Name }}(t *testing.T) {
 
 	defer func() { require.NoError(t, res.Body.Close()) }()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 
 	require.Equalf(t, http.StatusOK, res.StatusCode, string(body))

--- a/docker.go
+++ b/docker.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"regexp"
@@ -98,7 +97,7 @@ func (d *docker) pullImage(ctx context.Context, image string, cfg *Options) erro
 		}
 	}()
 
-	_, err = ioutil.ReadAll(reader)
+	_, err = io.ReadAll(reader)
 	if err != nil {
 		return fmt.Errorf("can't read server output: %w", err)
 	}

--- a/gnomock_test.go
+++ b/gnomock_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"testing"
 	"time"
@@ -151,7 +150,7 @@ func TestGnomock_withLogWriter(t *testing.T) {
 	go func() {
 		defer close(signal)
 
-		log, err := ioutil.ReadAll(r)
+		log, err := io.ReadAll(r)
 		require.NoError(t, err)
 		require.Contains(t, string(log), "starting with env1 = '', env2 = ''\n")
 	}()
@@ -180,7 +179,7 @@ func TestGnomock_withCommand(t *testing.T) {
 	go func() {
 		defer close(signal)
 
-		log, err := ioutil.ReadAll(r)
+		log, err := io.ReadAll(r)
 		require.NoError(t, err)
 		require.Contains(t, string(log), "[foo bar]")
 	}()
@@ -243,7 +242,7 @@ func requireResponse(t *testing.T, url string, expected string) {
 
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 
 	require.NoError(t, err)
 	require.Equal(t, expected, string(body))

--- a/internal/gnomockd/cassandra_test.go
+++ b/internal/gnomockd/cassandra_test.go
@@ -3,9 +3,10 @@ package gnomockd_test
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/orlangure/gnomock"
@@ -18,7 +19,7 @@ func TestCassandra(t *testing.T) {
 	t.Parallel()
 
 	h := gnomockd.Handler()
-	bs, err := ioutil.ReadFile("./testdata/cassandra.json")
+	bs, err := os.ReadFile("./testdata/cassandra.json")
 	require.NoError(t, err)
 
 	buf := bytes.NewBuffer(bs)
@@ -29,7 +30,7 @@ func TestCassandra(t *testing.T) {
 
 	defer func() { require.NoError(t, res.Body.Close()) }()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 
 	require.Equalf(t, http.StatusOK, res.StatusCode, string(body))

--- a/internal/gnomockd/cockroachdb_test.go
+++ b/internal/gnomockd/cockroachdb_test.go
@@ -5,9 +5,10 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/orlangure/gnomock"
@@ -20,7 +21,7 @@ func TestCockroachDB(t *testing.T) {
 	t.Parallel()
 
 	h := gnomockd.Handler()
-	bs, err := ioutil.ReadFile("./testdata/cockroachdb.json")
+	bs, err := os.ReadFile("./testdata/cockroachdb.json")
 	require.NoError(t, err)
 
 	buf := bytes.NewBuffer(bs)
@@ -31,7 +32,7 @@ func TestCockroachDB(t *testing.T) {
 
 	defer func() { require.NoError(t, res.Body.Close()) }()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 
 	require.Equalf(t, http.StatusOK, res.StatusCode, string(body))

--- a/internal/gnomockd/elastic_test.go
+++ b/internal/gnomockd/elastic_test.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/elastic/go-elasticsearch/v7"
@@ -25,7 +26,7 @@ func TestElastic(t *testing.T) {
 	t.Parallel()
 
 	h := gnomockd.Handler()
-	bs, err := ioutil.ReadFile("./testdata/elastic.json")
+	bs, err := os.ReadFile("./testdata/elastic.json")
 	require.NoError(t, err)
 
 	buf := bytes.NewBuffer(bs)
@@ -36,7 +37,7 @@ func TestElastic(t *testing.T) {
 
 	defer func() { require.NoError(t, res.Body.Close()) }()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 
 	require.Equalf(t, http.StatusOK, res.StatusCode, string(body))

--- a/internal/gnomockd/influxdb_test.go
+++ b/internal/gnomockd/influxdb_test.go
@@ -5,9 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
@@ -22,7 +23,7 @@ func TestInfluxDB(t *testing.T) {
 	t.Parallel()
 
 	h := gnomockd.Handler()
-	bs, err := ioutil.ReadFile("./testdata/influxdb.json")
+	bs, err := os.ReadFile("./testdata/influxdb.json")
 	require.NoError(t, err)
 
 	buf := bytes.NewBuffer(bs)
@@ -33,7 +34,7 @@ func TestInfluxDB(t *testing.T) {
 
 	defer func() { require.NoError(t, res.Body.Close()) }()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 
 	require.Equalf(t, http.StatusOK, res.StatusCode, string(body))

--- a/internal/gnomockd/k3s_test.go
+++ b/internal/gnomockd/k3s_test.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/orlangure/gnomock"
@@ -22,7 +23,7 @@ func TestK3s(t *testing.T) {
 	t.Parallel()
 
 	h := gnomockd.Handler()
-	bs, err := ioutil.ReadFile("./testdata/k3s.json")
+	bs, err := os.ReadFile("./testdata/k3s.json")
 	require.NoError(t, err)
 
 	buf := bytes.NewBuffer(bs)
@@ -33,7 +34,7 @@ func TestK3s(t *testing.T) {
 
 	defer func() { require.NoError(t, res.Body.Close()) }()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 
 	require.Equalf(t, http.StatusOK, res.StatusCode, string(body))

--- a/internal/gnomockd/kafka_test.go
+++ b/internal/gnomockd/kafka_test.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -21,7 +22,7 @@ func TestKafka(t *testing.T) {
 	t.Parallel()
 
 	h := gnomockd.Handler()
-	bs, err := ioutil.ReadFile("./testdata/kafka.json")
+	bs, err := os.ReadFile("./testdata/kafka.json")
 	require.NoError(t, err)
 
 	buf := bytes.NewBuffer(bs)
@@ -32,7 +33,7 @@ func TestKafka(t *testing.T) {
 
 	defer func() { require.NoError(t, res.Body.Close()) }()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 
 	require.Equalf(t, http.StatusOK, res.StatusCode, string(body))

--- a/internal/gnomockd/localstack_test.go
+++ b/internal/gnomockd/localstack_test.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -24,7 +25,7 @@ func TestLocalstack(t *testing.T) {
 	t.Parallel()
 
 	h := gnomockd.Handler()
-	bs, err := ioutil.ReadFile("./testdata/localstack.json")
+	bs, err := os.ReadFile("./testdata/localstack.json")
 	require.NoError(t, err)
 
 	buf := bytes.NewBuffer(bs)
@@ -35,7 +36,7 @@ func TestLocalstack(t *testing.T) {
 
 	defer func() { require.NoError(t, res.Body.Close()) }()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 
 	require.Equalf(t, http.StatusOK, res.StatusCode, string(body))
@@ -83,7 +84,7 @@ func TestLocalstack_invalidService(t *testing.T) {
 	t.Parallel()
 
 	h := gnomockd.Handler()
-	bs, err := ioutil.ReadFile("./testdata/localstack_invalid_service.json")
+	bs, err := os.ReadFile("./testdata/localstack_invalid_service.json")
 	require.NoError(t, err)
 
 	buf := bytes.NewBuffer(bs)
@@ -94,7 +95,7 @@ func TestLocalstack_invalidService(t *testing.T) {
 
 	defer func() { require.NoError(t, res.Body.Close()) }()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 
 	require.Equalf(t, http.StatusBadRequest, res.StatusCode, string(body))
@@ -104,7 +105,7 @@ func TestLocalstack_unknownService(t *testing.T) {
 	t.Parallel()
 
 	h := gnomockd.Handler()
-	bs, err := ioutil.ReadFile("./testdata/localstack_unknown_service.json")
+	bs, err := os.ReadFile("./testdata/localstack_unknown_service.json")
 	require.NoError(t, err)
 
 	buf := bytes.NewBuffer(bs)
@@ -115,7 +116,7 @@ func TestLocalstack_unknownService(t *testing.T) {
 
 	defer func() { require.NoError(t, res.Body.Close()) }()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 
 	require.Equalf(t, http.StatusBadRequest, res.StatusCode, string(body))

--- a/internal/gnomockd/mariadb_test.go
+++ b/internal/gnomockd/mariadb_test.go
@@ -5,9 +5,10 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/orlangure/gnomock"
@@ -20,7 +21,7 @@ func TestMariaDB(t *testing.T) {
 	t.Parallel()
 
 	h := gnomockd.Handler()
-	bs, err := ioutil.ReadFile("./testdata/mariadb.json")
+	bs, err := os.ReadFile("./testdata/mariadb.json")
 	require.NoError(t, err)
 
 	buf := bytes.NewBuffer(bs)
@@ -31,7 +32,7 @@ func TestMariaDB(t *testing.T) {
 
 	defer func() { require.NoError(t, res.Body.Close()) }()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 
 	require.Equalf(t, http.StatusOK, res.StatusCode, string(body))

--- a/internal/gnomockd/memcached_test.go
+++ b/internal/gnomockd/memcached_test.go
@@ -3,9 +3,10 @@ package gnomockd_test
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strconv"
 	"testing"
 
@@ -20,7 +21,7 @@ func TestMemcached(t *testing.T) {
 	t.Parallel()
 
 	h := gnomockd.Handler()
-	bs, err := ioutil.ReadFile("./testdata/memcached.json")
+	bs, err := os.ReadFile("./testdata/memcached.json")
 	require.NoError(t, err)
 
 	buf := bytes.NewBuffer(bs)
@@ -31,7 +32,7 @@ func TestMemcached(t *testing.T) {
 
 	defer func() { require.NoError(t, res.Body.Close()) }()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 
 	require.Equalf(t, http.StatusOK, res.StatusCode, string(body))

--- a/internal/gnomockd/mongo_test.go
+++ b/internal/gnomockd/mongo_test.go
@@ -5,9 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/orlangure/gnomock"
@@ -22,7 +23,7 @@ func TestMongo(t *testing.T) {
 	t.Parallel()
 
 	h := gnomockd.Handler()
-	bs, err := ioutil.ReadFile("./testdata/mongo.json")
+	bs, err := os.ReadFile("./testdata/mongo.json")
 	require.NoError(t, err)
 
 	buf := bytes.NewBuffer(bs)
@@ -33,7 +34,7 @@ func TestMongo(t *testing.T) {
 
 	defer func() { require.NoError(t, res.Body.Close()) }()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 
 	require.Equalf(t, http.StatusOK, res.StatusCode, string(body))

--- a/internal/gnomockd/mssql_test.go
+++ b/internal/gnomockd/mssql_test.go
@@ -5,9 +5,10 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/orlangure/gnomock"
@@ -20,7 +21,7 @@ func TestMSSQL(t *testing.T) {
 	t.Parallel()
 
 	h := gnomockd.Handler()
-	bs, err := ioutil.ReadFile("./testdata/mssql.json")
+	bs, err := os.ReadFile("./testdata/mssql.json")
 	require.NoError(t, err)
 
 	buf := bytes.NewBuffer(bs)
@@ -31,7 +32,7 @@ func TestMSSQL(t *testing.T) {
 
 	defer func() { require.NoError(t, res.Body.Close()) }()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 
 	require.Equalf(t, http.StatusOK, res.StatusCode, string(body))

--- a/internal/gnomockd/mysql_test.go
+++ b/internal/gnomockd/mysql_test.go
@@ -5,9 +5,10 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/orlangure/gnomock"
@@ -20,7 +21,7 @@ func TestMySQL(t *testing.T) {
 	t.Parallel()
 
 	h := gnomockd.Handler()
-	bs, err := ioutil.ReadFile("./testdata/mysql.json")
+	bs, err := os.ReadFile("./testdata/mysql.json")
 	require.NoError(t, err)
 
 	buf := bytes.NewBuffer(bs)
@@ -31,7 +32,7 @@ func TestMySQL(t *testing.T) {
 
 	defer func() { require.NoError(t, res.Body.Close()) }()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 
 	require.Equalf(t, http.StatusOK, res.StatusCode, string(body))

--- a/internal/gnomockd/postgres_test.go
+++ b/internal/gnomockd/postgres_test.go
@@ -5,9 +5,10 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/orlangure/gnomock"
@@ -20,7 +21,7 @@ func TestPostgres(t *testing.T) {
 	t.Parallel()
 
 	h := gnomockd.Handler()
-	bs, err := ioutil.ReadFile("./testdata/postgres.json")
+	bs, err := os.ReadFile("./testdata/postgres.json")
 	require.NoError(t, err)
 
 	buf := bytes.NewBuffer(bs)
@@ -31,7 +32,7 @@ func TestPostgres(t *testing.T) {
 
 	defer func() { require.NoError(t, res.Body.Close()) }()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 
 	require.Equalf(t, http.StatusOK, res.StatusCode, string(body))

--- a/internal/gnomockd/rabbitmq_test.go
+++ b/internal/gnomockd/rabbitmq_test.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/orlangure/gnomock"
@@ -20,7 +21,7 @@ func TestRabbitMQ(t *testing.T) {
 	t.Parallel()
 
 	h := gnomockd.Handler()
-	bs, err := ioutil.ReadFile("./testdata/rabbitmq.json")
+	bs, err := os.ReadFile("./testdata/rabbitmq.json")
 	require.NoError(t, err)
 
 	buf := bytes.NewBuffer(bs)
@@ -31,7 +32,7 @@ func TestRabbitMQ(t *testing.T) {
 
 	defer func() { require.NoError(t, res.Body.Close()) }()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 
 	require.Equalf(t, http.StatusOK, res.StatusCode, string(body))

--- a/internal/gnomockd/redis_test.go
+++ b/internal/gnomockd/redis_test.go
@@ -3,9 +3,10 @@ package gnomockd_test
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/go-redis/redis"
@@ -19,7 +20,7 @@ func TestRedis(t *testing.T) {
 	t.Parallel()
 
 	h := gnomockd.Handler()
-	bs, err := ioutil.ReadFile("./testdata/redis.json")
+	bs, err := os.ReadFile("./testdata/redis.json")
 	require.NoError(t, err)
 
 	buf := bytes.NewBuffer(bs)
@@ -30,7 +31,7 @@ func TestRedis(t *testing.T) {
 
 	defer func() { require.NoError(t, res.Body.Close()) }()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 
 	require.Equalf(t, http.StatusOK, res.StatusCode, string(body))

--- a/internal/gnomockd/splunk_test.go
+++ b/internal/gnomockd/splunk_test.go
@@ -5,10 +5,11 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"testing"
 
 	"github.com/orlangure/gnomock"
@@ -21,7 +22,7 @@ func TestSplunk(t *testing.T) {
 	t.Parallel()
 
 	h := gnomockd.Handler()
-	bs, err := ioutil.ReadFile("./testdata/splunk.json")
+	bs, err := os.ReadFile("./testdata/splunk.json")
 	require.NoError(t, err)
 
 	buf := bytes.NewBuffer(bs)
@@ -32,7 +33,7 @@ func TestSplunk(t *testing.T) {
 
 	defer func() { require.NoError(t, res.Body.Close()) }()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 
 	require.Equalf(t, http.StatusOK, res.StatusCode, string(body))
@@ -71,7 +72,7 @@ func TestSplunk(t *testing.T) {
 		} `json:"result"`
 	}{}
 
-	bs, err = ioutil.ReadAll(res.Body)
+	bs, err = io.ReadAll(res.Body)
 	require.NoError(t, err)
 	require.NoError(t, json.Unmarshal(bs, &out))
 	require.Equal(t, "525", out.Result.Count)

--- a/options.go
+++ b/options.go
@@ -3,7 +3,6 @@ package gnomock
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"time"
 )
 
@@ -260,7 +259,7 @@ func buildConfig(opts ...Option) *Options {
 		healthcheck:         nopHealthcheck,
 		healthcheckInterval: defaultHealthcheckInterval,
 		Timeout:             defaultTimeout,
-		logWriter:           ioutil.Discard,
+		logWriter:           io.Discard,
 	}
 
 	for _, opt := range opts {

--- a/preset/cockroachdb/preset.go
+++ b/preset/cockroachdb/preset.go
@@ -14,7 +14,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	_ "github.com/lib/pq" // postgres driver
 	"github.com/orlangure/gnomock"
@@ -122,7 +122,7 @@ func (p *P) initf() gnomock.InitFunc {
 
 		if len(p.QueriesFiles) > 0 {
 			for _, f := range p.QueriesFiles {
-				bs, err := ioutil.ReadFile(f) // nolint:gosec
+				bs, err := os.ReadFile(f) // nolint:gosec
 				if err != nil {
 					return fmt.Errorf("can't read queries file '%s': %w", f, err)
 				}

--- a/preset/k3s/preset.go
+++ b/preset/k3s/preset.go
@@ -32,7 +32,7 @@ package k3s
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/orlangure/gnomock"
@@ -189,7 +189,7 @@ func ConfigBytes(c *gnomock.Container) (configBytes []byte, err error) {
 		return nil, fmt.Errorf("invalid kubeconfig response code '%d'", res.StatusCode)
 	}
 
-	configBytes, err = ioutil.ReadAll(res.Body)
+	configBytes, err = io.ReadAll(res.Body)
 	if err != nil {
 		return nil, fmt.Errorf("can't read kubeconfig body: %w", err)
 	}

--- a/preset/localstack/options_s3.go
+++ b/preset/localstack/options_s3.go
@@ -2,7 +2,6 @@ package localstack
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -65,7 +64,7 @@ func (p *P) initS3(c *gnomock.Container) error {
 }
 
 func (p *P) createBuckets(svc *s3.S3) ([]string, error) {
-	files, err := ioutil.ReadDir(p.S3Path)
+	files, err := os.ReadDir(p.S3Path)
 	if err != nil {
 		return nil, fmt.Errorf("can't read s3 initial files: %w", err)
 	}

--- a/preset/mariadb/preset.go
+++ b/preset/mariadb/preset.go
@@ -5,8 +5,9 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
+	"os"
 	"sync"
 
 	mysqldriver "github.com/go-sql-driver/mysql"
@@ -68,7 +69,7 @@ func (p *P) Ports() gnomock.NamedPorts {
 func (p *P) Options() []gnomock.Option {
 	setLoggerOnce.Do(func() {
 		// err is always nil for non-nil logger
-		_ = mysqldriver.SetLogger(log.New(ioutil.Discard, "", -1))
+		_ = mysqldriver.SetLogger(log.New(io.Discard, "", -1))
 	})
 
 	p.setDefaults()
@@ -115,7 +116,7 @@ func (p *P) initf() gnomock.InitFunc {
 
 		if len(p.QueriesFiles) > 0 {
 			for _, f := range p.QueriesFiles {
-				bs, err := ioutil.ReadFile(f) // nolint:gosec
+				bs, err := os.ReadFile(f) // nolint:gosec
 				if err != nil {
 					return fmt.Errorf("can't read queries file '%s': %w", f, err)
 				}

--- a/preset/mongo/preset.go
+++ b/preset/mongo/preset.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -109,7 +108,7 @@ func (p *P) initf(ctx context.Context, c *gnomock.Container) error {
 		return fmt.Errorf("can't connect: %w", err)
 	}
 
-	topLevelDirs, err := ioutil.ReadDir(p.DataPath)
+	topLevelDirs, err := os.ReadDir(p.DataPath)
 	if err != nil {
 		return fmt.Errorf("can't read test data path: %w", err)
 	}
@@ -133,7 +132,7 @@ func (p *P) useCustomUser() bool {
 }
 
 func (p *P) setupDB(client *mongodb.Client, dirName string) error {
-	dataFiles, err := ioutil.ReadDir(path.Join(p.DataPath, dirName))
+	dataFiles, err := os.ReadDir(path.Join(p.DataPath, dirName))
 	if err != nil {
 		return fmt.Errorf("can't read test data sub path '%s', %w", dirName, err)
 	}

--- a/preset/mssql/preset.go
+++ b/preset/mssql/preset.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	_ "github.com/denisenkom/go-mssqldb" // mssql driver
 	"github.com/orlangure/gnomock"
@@ -118,7 +118,7 @@ func (p *P) initf() gnomock.InitFunc {
 
 		if len(p.QueriesFiles) > 0 {
 			for _, f := range p.QueriesFiles {
-				bs, err := ioutil.ReadFile(f) // nolint:gosec
+				bs, err := os.ReadFile(f) // nolint:gosec
 				if err != nil {
 					return fmt.Errorf("can't read queries file '%s': %w", f, err)
 				}

--- a/preset/mysql/preset.go
+++ b/preset/mysql/preset.go
@@ -5,8 +5,9 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
+	"os"
 	"sync"
 
 	mysqldriver "github.com/go-sql-driver/mysql"
@@ -68,7 +69,7 @@ func (p *P) Ports() gnomock.NamedPorts {
 func (p *P) Options() []gnomock.Option {
 	setLoggerOnce.Do(func() {
 		// err is always nil for non-nil logger
-		_ = mysqldriver.SetLogger(log.New(ioutil.Discard, "", -1))
+		_ = mysqldriver.SetLogger(log.New(io.Discard, "", -1))
 	})
 
 	p.setDefaults()
@@ -115,7 +116,7 @@ func (p *P) initf() gnomock.InitFunc {
 
 		if len(p.QueriesFiles) > 0 {
 			for _, f := range p.QueriesFiles {
-				bs, err := ioutil.ReadFile(f) // nolint:gosec
+				bs, err := os.ReadFile(f) // nolint:gosec
 				if err != nil {
 					return fmt.Errorf("can't read queries file '%s': %w", f, err)
 				}

--- a/preset/postgres/preset.go
+++ b/preset/postgres/preset.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	_ "github.com/lib/pq" // postgres driver
 	"github.com/orlangure/gnomock"
@@ -129,7 +129,7 @@ func (p *P) initf() gnomock.InitFunc {
 
 		if len(p.QueriesFiles) > 0 {
 			for _, f := range p.QueriesFiles {
-				bs, err := ioutil.ReadFile(f) // nolint:gosec
+				bs, err := os.ReadFile(f) // nolint:gosec
 				if err != nil {
 					return fmt.Errorf("can't read queries file '%s': %w", f, err)
 				}

--- a/preset/splunk/init.go
+++ b/preset/splunk/init.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -288,7 +287,7 @@ func requestWithAuth(ctx context.Context, method, password string, isJSON bool) 
 			}
 		}()
 
-		bs, err = ioutil.ReadAll(resp.Body)
+		bs, err = io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, fmt.Errorf("can't read response body: %w", err)
 		}

--- a/preset/splunk/preset_test.go
+++ b/preset/splunk/preset_test.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -92,7 +92,7 @@ func TestPreset(t *testing.T) {
 			} `json:"result"`
 		}{}
 
-		bs, err := ioutil.ReadAll(res.Body)
+		bs, err := io.ReadAll(res.Body)
 		require.NoError(t, err)
 		require.NoError(t, json.Unmarshal(bs, &r))
 		require.Equal(t, "99", r.Result.Count)


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). Since gnomock has been upgraded to Go 1.17 (#268), this PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.