### PR TITLE
Make protocol comparison case insensitive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/Microsoft/go-winio v0.5.0 // indirect
-	github.com/aws/aws-sdk-go v1.42.2
+	github.com/aws/aws-sdk-go v1.42.3
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b
 	github.com/containerd/containerd v1.5.7 // indirect
 	github.com/denisenkom/go-mssqldb v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:l
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aws/aws-sdk-go v1.42.2 h1:SXA+B3DT4N3+wJw5X4Jz9/PazkQZQ7k1nXLGZRdFbO4=
 github.com/aws/aws-sdk-go v1.42.2/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
+github.com/aws/aws-sdk-go v1.42.3 h1:lBKr3tQ06m1uykiychMNKLK1bRfOzaIEQpsI/S3QiNc=
+github.com/aws/aws-sdk-go v1.42.3/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/internal/israce/norace.go
+++ b/internal/israce/norace.go
@@ -1,3 +1,4 @@
+//go:build !race
 // +build !race
 
 // Package israce reports if the Go race detector is enabled.

--- a/options.go
+++ b/options.go
@@ -153,7 +153,7 @@ func WithDisableAutoCleanup() Option {
 	}
 }
 
-// UseLocalImagesFirst if possible to avoid hitting the Docker Hub pull rate limit.
+// WithUseLocalImagesFirst if possible to avoid hitting the Docker Hub pull rate limit.
 func WithUseLocalImagesFirst() Option {
 	return func(o *Options) {
 		o.UseLocalImagesFirst = true

--- a/ports.go
+++ b/ports.go
@@ -1,6 +1,9 @@
 package gnomock
 
-import "errors"
+import (
+	"errors"
+	"strings"
+)
 
 // DefaultPort should be used with simple containers that expose only one TCP
 // port. Use DefaultTCP function when creating a container, and use DefaultPort
@@ -59,7 +62,7 @@ func (p NamedPorts) Get(name string) Port {
 // protocol are known.
 func (p NamedPorts) Find(proto string, portNum int) (string, error) {
 	for name, port := range p {
-		if proto == port.Protocol && portNum == port.Port {
+		if strings.EqualFold(proto, port.Protocol) && portNum == port.Port {
 			return name, nil
 		}
 	}


### PR DESCRIPTION
This commit makes it easier to avoid custom port configuration mistakes,
such as using "TCP" port instead of "tcp". The error message returned
from that area is now more clear.