### PR TITLE
Make 0.13.1 the default version of localstack

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ versions might work as well.*</small>
 
 | Preset | Go package | HTTP API | Go API | Supported versions |
 |--------|------------|----------|--------|---------------------|
-Localstack (AWS) | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/localstack) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.7.0#/presets/startLocalstack) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/localstack?tab=doc) | `0.12.2`
+Localstack (AWS) | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/localstack) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.7.0#/presets/startLocalstack) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/localstack?tab=doc) | `0.12.2`, `0.13.1`
 Splunk | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/splunk) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.7.0#/presets/startSplunk) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/splunk?tab=doc) | `8.0.2`
 Redis | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/redis) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.7.0#/presets/startRedis) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/redis?tab=doc) | `5.0.10`, `6.0.9`
 Memcached | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/memcached) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.7.0#/presets/startMemcached) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/memcached?tab=doc) | `1.6.9`

--- a/preset/localstack/preset.go
+++ b/preset/localstack/preset.go
@@ -22,7 +22,7 @@ const (
 	APIPort = "api"
 )
 
-const defaultVersion = "0.12.2"
+const defaultVersion = "0.13.1"
 
 func init() {
 	registry.Register("localstack", func() gnomock.Preset { return &P{} })
@@ -129,7 +129,9 @@ func (p *P) healthcheck(services []string) gnomock.HealthcheckFunc {
 
 		for _, service := range services {
 			status := hr.Services[service]
-			if status != "running" {
+			// available status was added in 0.13.0: it allows to lazy load the
+			// services after the first request
+			if status != "running" && status != "available" {
 				return fmt.Errorf("service '%s' is not running", service)
 			}
 		}


### PR DESCRIPTION
Since 0.13.0 localstack support lazy loading of services, which should
make the container available faster. This version would now be the
default, but 0.12.2 which was the default before now has its own test to
make sure it still works.

Closes #356 