### PR TITLE
Support explicit port mappings in remote mode

### DIFF
--- a/internal/gnomockd/gnomockd_test.go
+++ b/internal/gnomockd/gnomockd_test.go
@@ -2,10 +2,13 @@ package gnomockd_test
 
 import (
 	"bytes"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/orlangure/gnomock"
 	"github.com/orlangure/gnomock/internal/gnomockd"
 	_ "github.com/orlangure/gnomock/preset/mongo" // this is only to prevent error 404
 	"github.com/stretchr/testify/require"
@@ -73,7 +76,7 @@ func TestGnomockd(t *testing.T) {
 		t.Parallel()
 
 		h := gnomockd.Handler()
-		buf := bytes.NewBuffer([]byte(`{"id":"invalid"}`))
+		buf := bytes.NewBufferString(`{"id":"invalid"}`)
 		w, r := httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/stop", buf)
 		h.ServeHTTP(w, r)
 
@@ -82,5 +85,38 @@ func TestGnomockd(t *testing.T) {
 		defer func() { require.NoError(t, res.Body.Close()) }()
 
 		require.Equal(t, http.StatusInternalServerError, res.StatusCode)
+	})
+
+	t.Run("fixed host port using custom named ports", func(t *testing.T) {
+		t.Parallel()
+
+		port := gnomock.TCP(27017)
+		port.HostPort = 43210
+
+		body, err := json.Marshal(struct {
+			Options gnomock.Options `json:"options"`
+		}{
+			gnomock.Options{
+				CustomNamedPorts: gnomock.NamedPorts{
+					gnomock.DefaultPort: port,
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		h := gnomockd.Handler()
+		w, r := httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/start/mongo", bytes.NewBuffer(body))
+		h.ServeHTTP(w, r)
+
+		res := w.Result()
+		t.Cleanup(func() { require.NoError(t, res.Body.Close()) })
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		body, err = io.ReadAll(res.Body)
+		require.NoError(t, err)
+
+		c := gnomock.Container{}
+		require.NoError(t, json.Unmarshal(body, &c))
+		require.Equal(t, 43210, c.DefaultPort())
 	})
 }

--- a/options.go
+++ b/options.go
@@ -117,6 +117,10 @@ func WithOptions(options *Options) Option {
 			o.Timeout = options.Timeout
 		}
 
+		if options.CustomNamedPorts != nil {
+			o.CustomNamedPorts = options.CustomNamedPorts
+		}
+
 		o.Env = append(o.Env, options.Env...)
 		o.Debug = options.Debug
 		o.ContainerName = options.ContainerName
@@ -157,6 +161,14 @@ func WithDisableAutoCleanup() Option {
 func WithUseLocalImagesFirst() Option {
 	return func(o *Options) {
 		o.UseLocalImagesFirst = true
+	}
+}
+
+// WithCustomNamedPorts allows to define custom ports for a container. This
+// option should be used to override the ports defined by presets.
+func WithCustomNamedPorts(namedPorts NamedPorts) Option {
+	return func(o *Options) {
+		o.CustomNamedPorts = namedPorts
 	}
 }
 
@@ -233,6 +245,18 @@ type Options struct {
 	// WithUseLocalImagesFirst allows to use existing local images if possible
 	// instead of always pulling the images.
 	UseLocalImagesFirst bool `json:"use_local_images_first"`
+
+	// CustomNamedPorts allows to override the ports set by the presets. This
+	// option is useful for cases when the presets need to be created with
+	// custom port definitions. This is an advanced feature and should be used
+	// with care.
+	//
+	// Note that when using this option, you should provide custom named ports
+	// with names matching the original ports returned by the used preset.
+	//
+	// When calling StartCustom directly from Go, it is possible to provide the
+	// ports directly to the function.
+	CustomNamedPorts NamedPorts `json:"custom_named_ports"`
 
 	// Base64 encoded JSON string with docker access credentials. JSON string
 	// should include two fields: username and password. For Docker Hub, if 2FA

--- a/preset_test.go
+++ b/preset_test.go
@@ -97,3 +97,23 @@ func TestPreset_duplicateContainerName(t *testing.T) {
 	require.Error(t, gnomock.Stop(originalContainer))
 	require.NoError(t, gnomock.Stop(newContainer))
 }
+
+func TestPreset_customNamedPorts(t *testing.T) {
+	t.Parallel()
+
+	p := &testutil.TestPreset{Img: testutil.TestImage}
+	presetPorts := p.Ports()
+	pr := presetPorts["web80"]
+	pr.HostPort = 23080
+	presetPorts["web80"] = pr
+
+	container, err := gnomock.Start(
+		p,
+		gnomock.WithCustomNamedPorts(presetPorts),
+		gnomock.WithDebugMode(),
+	)
+
+	t.Cleanup(func() { require.NoError(t, gnomock.Stop(container)) })
+	require.NoError(t, err)
+	require.Equal(t, 23080, container.Ports.Get("web80").Port)
+}

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -478,6 +478,8 @@ components:
         use_local_images_first:
           type: boolean
           description: If possible to avoid hitting the Docker Hub pull rate limit.
+        custom_named_ports:
+          $ref: '#/components/schemas/named-ports'
         auth:
           type: string
           description: >


### PR DESCRIPTION
When gnomock runs in server mode, it is impossible to control the port
mappings created by the presets. In this commit I add an ability to
override preset-specific named ports by any other values in order to
control which ports are allocated by the remote gnomock instance.

This feature is a bit fragile, because the user is required to study the
preset before attempting to override its built-in values. Custom named
ports must expose the ports with the same names and internal ports for
the override to work. Basically, only the "host port" value should be
changed.

This commit fixes https://github.com/orlangure/gnomock/issues/441.