### PR TITLE
Make 0.14.0 default localstack version

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ versions might work as well.*</small>
 
 | Preset | Go package | HTTP API | Go API | Supported versions |
 |--------|------------|----------|--------|---------------------|
-Localstack (AWS) | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/localstack) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.19.0#/presets/startLocalstack) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/localstack?tab=doc) | `0.12.2`, `0.13.1`
+[Localstack](https://github.com/localstack/localstack) (AWS) | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/localstack) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.19.0#/presets/startLocalstack) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/localstack?tab=doc) | `0.12.2`, `0.13.1`, `0.14.0`
 Splunk | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/splunk) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.19.0#/presets/startSplunk) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/splunk?tab=doc) | `8.0.2`
 Redis | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/redis) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.19.0#/presets/startRedis) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/redis?tab=doc) | `5.0.10`, `6.0.9`
 Memcached | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/memcached) | [Docs](https://app.swaggerhub.com/apis/orlangure/gnomock/1.19.0#/presets/startMemcached) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/memcached?tab=doc) | `1.6.9`

--- a/preset/localstack/preset.go
+++ b/preset/localstack/preset.go
@@ -22,7 +22,7 @@ const (
 	APIPort = "api"
 )
 
-const defaultVersion = "0.13.1"
+const defaultVersion = "0.14.0"
 
 func init() {
 	registry.Register("localstack", func() gnomock.Preset { return &P{} })

--- a/preset/localstack/preset_test.go
+++ b/preset/localstack/preset_test.go
@@ -20,7 +20,7 @@ import (
 func TestPreset_s3(t *testing.T) {
 	t.Parallel()
 
-	for _, version := range []string{"0.12.2", "0.13.1"} {
+	for _, version := range []string{"0.12.2", "0.13.1", "0.14.0"} {
 		t.Run(version, testS3(version))
 	}
 }


### PR DESCRIPTION
This version of localstack includes breaking changes, but the tests
still pass. The new version is now default, and it is added to the list
of supported versions.