### PR TITLE
feat: network option

### DIFF
--- a/options.go
+++ b/options.go
@@ -96,6 +96,12 @@ func WithContainerName(name string) Option {
 	}
 }
 
+func WithNetwork(name string) Option {
+	return func(o *Options) {
+		o.Network = name
+	}
+}
+
 // WithPrivileged starts a container in privileged mode (like `docker run
 // --privileged`). This option should not be used unless you really need it.
 // One use case for this option would be to run a Preset that has some kind of
@@ -268,6 +274,11 @@ type Options struct {
 	// which stands for
 	//	{"username":"foo","password":"bar"}
 	Auth string `json:"auth"`
+
+	// Network allows to specify the name of the network which the container
+	// will run on. If the specified network doesn't exist, it will create it.
+	//  Otherwise, it will use the existing network.
+	Network string `json:"network"`
 
 	ctx                 context.Context
 	init                InitFunc


### PR DESCRIPTION
# Context
gnomock works great when you have to run a couple of independent containers to test your application, but as soon as you require communication between those containers, things get tricky. I've tried a couple of approaches but couldn't manage to make a container communicate with another.

# Solution
This PR adds a new option `gnomock.WithNetwork("network name")` that allows a user to define which network the containers should run on. This allows communication between containers using the container name as its hostname.

## Example
```go
dbContainerName := "db"
_, err := gnomock.Start(
    postgresPreset,
    gnomock.WithNetwork("example"),
    gnomock.WithContainerName(dbContainerName),
)

_, err := gnomock,StartCustom(
    "custom/my-api",
    gnomock.DefaultTCP(80),
    gnomock.WithEnv(fmt.Sprintf("DATABASE_HOST=%s", dbContainerName)),
    gnomock.WithNetwork("example"),
)
```

## How it works
If `options.Network` is provided, check if there is an existing network with that name, if yes, use the existing network. Otherwise, create a new one and use it.