### PR TITLE
server.md: Remove comment from example

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -34,7 +34,7 @@ docker run --rm \
     -p 23042:23042 \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v $PWD:$PWD \
-    --privileged \ # this flag may be required on some systems
+    --privileged \
     orlangure/gnomock
 ```
 
@@ -45,6 +45,8 @@ can use any port you like, just make sure to configure the client properly.
 with the docker engine running on host. Without it `gnomock` can't access
 docker.
 
+`--privileged` may be required on some systems.
+ 
 If you use any file-related `gnomock` options, like `WithQueriesFile`, you have
 to make the path you use available inside the container:
 


### PR DESCRIPTION
In zsh, the comment after the \ causes:
docker: invalid reference format.
See 'docker run --help'.
zsh: no such file or directory: orlangure/gnomock