### PR TITLE
Suggestion: Add image name to kafka preset

### DIFF
--- a/preset/kafka/options.go
+++ b/preset/kafka/options.go
@@ -19,6 +19,12 @@ func WithTopics(topics ...string) Option {
 	}
 }
 
+func WithImage(imageName string) Option {
+	return func(o *P) {
+		o.ImageName = imageName
+	}
+}
+
 // WithMessages makes sure that these messages can be consumed during the test
 // once the container is ready.
 func WithMessages(messages ...Message) Option {

--- a/preset/kafka/preset.go
+++ b/preset/kafka/preset.go
@@ -66,6 +66,7 @@ type P struct {
 	Topics        []string  `json:"topics"`
 	Messages      []Message `json:"messages"`
 	MessagesFiles []string  `json:"messages_files"`
+	ImageName     string    `json:"image_name"`
 }
 
 // Image returns an image that should be pulled to create this container.

--- a/preset/kafka/preset.go
+++ b/preset/kafka/preset.go
@@ -23,10 +23,11 @@ const (
 )
 
 const (
-	defaultVersion = "2.5.1-L0"
-	brokerPort     = 49092
-	zookeeperPort  = 2181
-	webPort        = 3030
+	defaultVersion   = "2.5.1-L0"
+	defaultImageName = "lensesio/fast-data-dev"
+	brokerPort       = 49092
+	zookeeperPort    = 2181
+	webPort          = 3030
 )
 
 // Message is a single message sent to Kafka.
@@ -71,7 +72,7 @@ type P struct {
 
 // Image returns an image that should be pulled to create this container.
 func (p *P) Image() string {
-	return fmt.Sprintf("docker.io/lensesio/fast-data-dev:%s", p.Version)
+	return fmt.Sprintf("%s:%s", p.ImageName, p.Version)
 }
 
 // Ports returns ports that should be used to access this container.
@@ -140,6 +141,10 @@ func (p *P) healthcheck(ctx context.Context, c *gnomock.Container) (err error) {
 func (p *P) setDefaults() {
 	if p.Version == "" {
 		p.Version = defaultVersion
+	}
+
+	if p.ImageName == "" {
+		p.ImageName = defaultImageName
 	}
 }
 


### PR DESCRIPTION
Since this image for kafka doesn't really work with M1 (yet) there has been a need to override the default image name

Good idea or not to have this in the main repo?

