### PR TITLE
Support schema registry in kafka preset

### DIFF
--- a/preset/kafka/options.go
+++ b/preset/kafka/options.go
@@ -34,3 +34,13 @@ func WithMessagesFile(files string) Option {
 		o.MessagesFiles = append(o.MessagesFiles, files)
 	}
 }
+
+// WithSchemaRegistry makes the container wait for the schema registry port to
+// become available. Note that it takes longer to setup schema registry than
+// the broker itself. Gnomock will not wait for the registry by default, but it
+// may become available eventually.
+func WithSchemaRegistry() Option {
+	return func(o *P) {
+		o.UseSchemaRegistry = true
+	}
+}

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -1038,6 +1038,10 @@ components:
           description: Kafka version.
           default: 2.5.1-L0
           example: latest
+        use_schema_registry:
+          type: boolean
+          description: Set to true to wait for schema registry on startup
+          default: false
       description: >
         This object describes a Kafka container.
 


### PR DESCRIPTION
Schema registry startup time is a bit longer than the broker, so registry usage is hidden behind a flag to not make existing tests slower.