### PR TITLE
Made it possible to override `entrypoint`

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -306,6 +306,10 @@ func (d *docker) createContainer(ctx context.Context, image string, ports NamedP
 		containerConfig.Cmd = cfg.Cmd
 	}
 
+	if len(cfg.Entrypoint) > 0 {
+		containerConfig.Entrypoint = cfg.Entrypoint
+	}
+
 	mounts := []mount.Mount{}
 	for src, dst := range cfg.HostMounts {
 		mounts = append(mounts, mount.Mount{

--- a/gnomock_test.go
+++ b/gnomock_test.go
@@ -221,17 +221,13 @@ func TestGnomock_withEntrypoint(t *testing.T) {
 		require.NoError(t, r.Close())
 	})
 	t.Run("overwriting entrypoint with a new entrypoint", func(t *testing.T) {
-		_, w := io.Pipe()
-
 		_, err := gnomock.StartCustom(
 			testutil.TestImage,
 			gnomock.DefaultTCP(testutil.GoodPort80),
-			gnomock.WithLogWriter(w),
 			gnomock.WithEntrypoint("echo"),
 		)
 
 		require.ErrorContains(t, err, "\"echo\": executable file not found in $PATH")
-		require.NoError(t, w.Close())
 	})
 }
 

--- a/gnomock_test.go
+++ b/gnomock_test.go
@@ -227,11 +227,10 @@ func TestGnomock_withEntrypoint(t *testing.T) {
 			testutil.TestImage,
 			gnomock.DefaultTCP(testutil.GoodPort80),
 			gnomock.WithLogWriter(w),
-			gnomock.WithEntrypoint("sh", "-c"),
-			gnomock.WithCommand("/app", "foo", "bar"),
+			gnomock.WithEntrypoint("echo"),
 		)
 
-		require.ErrorContains(t, err, "\"sh\": executable file not found in $PATH")
+		require.ErrorContains(t, err, "\"echo\": executable file not found in $PATH")
 		require.NoError(t, w.Close())
 	})
 }

--- a/options.go
+++ b/options.go
@@ -136,7 +136,7 @@ func WithCommand(cmd string, args ...string) Option {
 }
 
 // WithEntrypoint overwrites the entrypoint, and its arguments, defined
-// in the original docker image
+// in the original docker image.
 func WithEntrypoint(entrypoint string, args ...string) Option {
 	return func(o *Options) {
 		o.Entrypoint = append([]string{entrypoint}, args...)

--- a/options.go
+++ b/options.go
@@ -135,6 +135,14 @@ func WithCommand(cmd string, args ...string) Option {
 	}
 }
 
+// WithEntrypoint overwrites the entrypoint, and its arguments, defined
+// in the original docker image
+func WithEntrypoint(entrypoint string, args ...string) Option {
+	return func(o *Options) {
+		o.Entrypoint = append([]string{entrypoint}, args...)
+	}
+}
+
 // WithHostMounts allows to bind host path (`src`) inside the container under
 // `dst` path.
 func WithHostMounts(src, dst string) Option {
@@ -244,6 +252,10 @@ type Options struct {
 	// level.
 	Cmd []string `json:"cmd"`
 
+	// Entrypoint is the binary that will always be executed when the container
+	// is run. The difference between this and Cmd, is that Cmd will be given as an
+	// argument to Entrypoint.
+	Entrypoint []string `json:"entrypoint"`
 	// HostMounts allows to mount local paths into the container.
 	HostMounts map[string]string `json:"host_mounts"`
 


### PR DESCRIPTION
Quite often you have an image, and you want to change the ENTRYPOINT.

This is a very tiny change, all that I did was to create a new option.