### PR TITLE
Enable race detector in elastic tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,10 +46,10 @@ jobs:
       - setup-for-go-test
       - run:
           name: Test preset
-          command: go test -cover -v ./preset/elastic/...
+          command: go test -race -cover -v ./preset/elastic/...
       - run:
           name: Test server
-          command: go test -v ./internal/gnomockd -run TestElastic
+          command: go test -race -v ./internal/gnomockd -run TestElastic
 
   test-memcached:
     machine: true
@@ -219,7 +219,7 @@ jobs:
       - run:
           name: Test server
           command: go test -race -cover -v ./internal/gnomockd -run TestCassandra
-  
+
   test-vault:
     machine: true
     resource_class: large

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -143,9 +143,9 @@ jobs:
       - name: Get dependencies
         run: go get -v -t -d ./...
       - name: Test preset
-        run: go test -cover -covermode=atomic -coverprofile=preset-cover.txt -coverpkg=./... -v ./preset/elastic/...
+        run: go test -race -cover -covermode=atomic -coverprofile=preset-cover.txt -coverpkg=./... -v ./preset/elastic/...
       - name: Test server
-        run: go test -cover -covermode=atomic -coverprofile=server-cover.txt -coverpkg=./... -v ./internal/gnomockd -run TestElastic
+        run: go test -race -cover -covermode=atomic -coverprofile=server-cover.txt -coverpkg=./... -v ./internal/gnomockd -run TestElastic
       - name: Report coverage
         run: |
           cat preset-cover.txt server-cover.txt > coverage.txt

--- a/internal/gnomockd/elastic_test.go
+++ b/internal/gnomockd/elastic_test.go
@@ -13,16 +13,11 @@ import (
 	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/orlangure/gnomock"
 	"github.com/orlangure/gnomock/internal/gnomockd"
-	"github.com/orlangure/gnomock/internal/israce"
 	_ "github.com/orlangure/gnomock/preset/elastic"
 	"github.com/stretchr/testify/require"
 )
 
 func TestElastic(t *testing.T) {
-	if israce.Enabled {
-		t.Skip("elastic tests can't run with race detector due to https://github.com/elastic/go-elasticsearch/issues/147")
-	}
-
 	t.Parallel()
 
 	h := gnomockd.Handler()

--- a/preset/elastic/preset_test.go
+++ b/preset/elastic/preset_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/orlangure/gnomock"
-	"github.com/orlangure/gnomock/internal/israce"
 	"github.com/orlangure/gnomock/preset/elastic"
 	"github.com/stretchr/testify/require"
 )
@@ -16,10 +15,6 @@ import (
 // resources
 
 func TestPreset(t *testing.T) {
-	if israce.Enabled {
-		t.Skip("elastic tests can't run with race detector due to https://github.com/elastic/go-elasticsearch/issues/147")
-	}
-
 	p := elastic.Preset(
 		elastic.WithVersion("8.7.0"),
 		elastic.WithInputFile("./testdata/titles"),
@@ -71,10 +66,6 @@ func TestPreset(t *testing.T) {
 }
 
 func TestPreset_withDefaults(t *testing.T) {
-	if israce.Enabled {
-		t.Skip("elastic tests can't run with race detector due to https://github.com/elastic/go-elasticsearch/issues/147")
-	}
-
 	p := elastic.Preset()
 	c, err := gnomock.Start(p)
 	require.NoError(t, err)

--- a/preset/elastic/preset_v7_test.go
+++ b/preset/elastic/preset_v7_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/elastic/go-elasticsearch/v7"
 	"github.com/orlangure/gnomock"
-	"github.com/orlangure/gnomock/internal/israce"
 	"github.com/orlangure/gnomock/preset/elastic"
 	"github.com/stretchr/testify/require"
 )
@@ -16,10 +15,6 @@ import (
 // resources
 
 func TestPreset_v7(t *testing.T) {
-	if israce.Enabled {
-		t.Skip("elastic tests can't run with race detector due to https://github.com/elastic/go-elasticsearch/issues/147")
-	}
-
 	p := elastic.Preset(
 		elastic.WithVersion("7.17.9"),
 		elastic.WithInputFile("./testdata/titles"),


### PR DESCRIPTION
Thanks to @MarvinZeising, race detector can be re-enabled in Elastic tests 😼