### PR TITLE
make gnomock compatible with localstack 2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The power of Gnomock is in the Presets. Existing Presets with their supported<su
 
 | Preset | Go package | Go API | Supported versions                        | arm64 |
 |--------|------------|--------|-------------------------------------------|-------|
-[Localstack](https://github.com/localstack/localstack) (AWS) | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/localstack) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/localstack?tab=doc) | `0.12.2`, `0.13.1`, `0.14.0`              | ✅
+[Localstack](https://github.com/localstack/localstack) (AWS) | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/localstack) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/localstack?tab=doc) | `0.12.2`, `0.13.1`, `0.14.0`, `2.3.0`              | ✅
 Splunk | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/splunk) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/splunk?tab=doc) | `8.0.2`                                   | ❌
 Redis | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/redis) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/redis?tab=doc) | `5.0.10`, `6.0.9`                         | ✅
 Memcached | [Go package](https://github.com/orlangure/gnomock/tree/master/preset/memcached) | [Reference](https://pkg.go.dev/github.com/orlangure/gnomock/preset/memcached?tab=doc) | `1.6.9`                                   | ✅

--- a/preset/localstack/preset.go
+++ b/preset/localstack/preset.go
@@ -16,13 +16,11 @@ import (
 )
 
 const (
-	webPort = "web"
-
 	// APIPort should be used to configure AWS SDK endpoint.
 	APIPort = "api"
 )
 
-const defaultVersion = "0.14.0"
+const defaultVersion = "2.3.0"
 
 func init() {
 	registry.Register("localstack", func() gnomock.Preset { return &P{} })
@@ -59,7 +57,6 @@ func (p *P) Image() string {
 // Ports returns ports that should be used to access this container.
 func (p *P) Ports() gnomock.NamedPorts {
 	return gnomock.NamedPorts{
-		webPort: {Protocol: "tcp", Port: 8080},
 		APIPort: {Protocol: "tcp", Port: 4566},
 	}
 }
@@ -144,7 +141,7 @@ func (p *P) healthcheck(services []string) gnomock.HealthcheckFunc {
 // localstack container. Before version 0.11.3, the endpoint was available at
 // port 8080. In 0.11.3, the endpoint was moved to the default port (4566).
 func (p *P) healthCheckAddress(c *gnomock.Container) string {
-	defaultPath := fmt.Sprintf("http://%s/health", c.Address(APIPort))
+	defaultPath := fmt.Sprintf("http://%s/_localstack/health", c.Address(APIPort))
 
 	if p.Version == defaultVersion {
 		return defaultPath
@@ -182,7 +179,7 @@ func (p *P) healthCheckAddress(c *gnomock.Container) string {
 		return defaultPath
 	}
 
-	return fmt.Sprintf("http://%s/health", c.Address(webPort))
+	return fmt.Sprintf("http://%s/_localstack/health", c.Address(APIPort))
 }
 
 type healthResponse struct {

--- a/preset/localstack/preset_test.go
+++ b/preset/localstack/preset_test.go
@@ -20,7 +20,7 @@ import (
 func TestPreset_s3(t *testing.T) {
 	t.Parallel()
 
-	for _, version := range []string{"0.12.2", "0.13.1", "0.14.0"} {
+	for _, version := range []string{"0.12.2", "0.13.1", "0.14.0", "2.3.0"} {
 		t.Run(version, testS3(version))
 	}
 }


### PR DESCRIPTION
## List of changes

- Upgraded the image to `2.3.0`: LocalStack 1.0 and 2.0 has shipped various changes that improves parity against the real AWS, including better S3 & Lambda providers. I have pinned the tag to [2.3.0](https://discuss.localstack.cloud/t/localstack-release-v2-3-0/533).
- Updated the `/health` endpoint to the new `/_localstack/health` endpoint. With LocalStack 1.3, the `localhost:4566/_health` is being deprecated. The new health endpoint ensures that the `healthcheck` service runs properly.
- Removes the `webPort` since the local Web UI is no longer available and has been removed from the new images. 