### PR TITLE
Add network option

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/mount"
+	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/go-connections/nat"
@@ -114,6 +115,19 @@ func (d *docker) pullImage(ctx context.Context, image string, cfg *Options) erro
 	d.log.Info("image pulled")
 
 	return nil
+}
+
+func (d *docker) startNetwork(ctx context.Context, name string) (string, error) {
+	resp, err := d.client.NetworkCreate(ctx, name, types.NetworkCreate{})
+	if err != nil {
+		return "", fmt.Errorf("can't create network: %w", err)
+	}
+
+	return resp.ID, nil
+}
+
+func (d *docker) stopNetwork(ctx context.Context, nwID string) error {
+	return d.client.NetworkRemove(ctx, nwID)
 }
 
 func (d *docker) startContainer(ctx context.Context, image string, ports NamedPorts, cfg *Options) (*Container, error) {
@@ -339,7 +353,12 @@ func (d *docker) createContainer(
 		ExtraHosts:   cfg.ExtraHosts,
 	}
 
-	resp, err := d.client.ContainerCreate(ctx, containerConfig, hostConfig, nil, nil, cfg.ContainerName)
+	nwConfig, err := d.findNetworkingConfig(ctx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("can't find network: %w", err)
+	}
+
+	resp, err := d.client.ContainerCreate(ctx, containerConfig, hostConfig, nwConfig, nil, cfg.ContainerName)
 	if err == nil {
 		return &resp, nil
 	}
@@ -359,6 +378,35 @@ func (d *docker) createContainer(
 	}
 
 	return &resp, err
+}
+
+// findNetworkingConfig finds the network associated with the network ID and
+// builds a NetworkingConfig with it if a network ID is provided.
+func (d *docker) findNetworkingConfig(ctx context.Context, cfg *Options) (*network.NetworkingConfig, error) {
+	if cfg.NetworkID == "" {
+		return nil, nil
+	}
+
+	nws, err := d.client.NetworkList(ctx, types.NetworkListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("can't list networks: %w", err)
+	}
+
+	for _, nw := range nws {
+		if cfg.NetworkID == nw.ID {
+			nwConfig := &network.NetworkingConfig{
+				EndpointsConfig: map[string]*network.EndpointSettings{
+					nw.Name: {
+						NetworkID: nw.ID,
+					},
+				},
+			}
+
+			return nwConfig, nil
+		}
+	}
+
+	return nil, fmt.Errorf("network '%s' does not exist", cfg.NetworkID)
 }
 
 func (d *docker) findReusableContainer(

--- a/gnomock.go
+++ b/gnomock.go
@@ -341,3 +341,48 @@ func isHostDockerInternalAvailable() bool {
 
 	return err == nil
 }
+
+// StartNetwork creates a new network. The returned string is the ID of the
+// created network.
+func StartNetwork(ctx context.Context, name string) (string, error) {
+	g, err := newG(false)
+	if err != nil {
+		return "", fmt.Errorf("can't create new gnomock session: %w", err)
+	}
+
+	defer func() { _ = g.log.Sync() }()
+
+	cli, err := g.dockerConnect()
+	if err != nil {
+		return "", fmt.Errorf("can't create docker client: %w", err)
+	}
+
+	return cli.startNetwork(ctx, name)
+}
+
+// StopNetwork removes the networks associated with the provided network IDs.
+func StopNetwork(ctx context.Context, nwIDs ...string) (err error) {
+	g, err := newG(false)
+	if err != nil {
+		return fmt.Errorf("can't create new gnomock session: %w", err)
+	}
+
+	defer func() { _ = g.log.Sync() }()
+
+	cli, err := g.dockerConnect()
+	if err != nil {
+		return fmt.Errorf("can't create docker client: %w", err)
+	}
+
+	var eg errgroup.Group
+
+	for _, n := range nwIDs {
+		nwID := n
+
+		eg.Go(func() error {
+			return cli.stopNetwork(ctx, nwID)
+		})
+	}
+
+	return eg.Wait()
+}

--- a/options.go
+++ b/options.go
@@ -233,6 +233,15 @@ func nopInit(context.Context, *Container) error {
 	return nil
 }
 
+// WithNetworkID allows to specify a custom network to attach the container to
+// by providing the network ID of a network that has already been created.
+// See StartNetwork and StopNetwork for more details.
+func WithNetworkID(nwID string) Option {
+	return func(o *Options) {
+		o.NetworkID = nwID
+	}
+}
+
 // Options includes Gnomock startup configuration. Functional options
 // (WithSomething) should be used instead of directly initializing objects of
 // this type whenever possible.
@@ -306,6 +315,9 @@ type Options struct {
 	// Reuse prevents the container from being automatically stopped and enables
 	// its re-use in posterior executions.
 	Reuse bool `json:"reuse"`
+
+	// NetworkID is the ID of a custom network the container should attach to.
+	NetworkID string `json:"networkID"`
 
 	ctx                 context.Context
 	init                InitFunc


### PR DESCRIPTION
I was seeking a solution for writing tests that deal with multiple containers that all need to be able to talk to each other.

I found https://github.com/orlangure/gnomock/pull/534 but it looked like it might've gone stale so I decided to build upon the work that they had already started (I hope that's ok!).

Instead of creating the network while starting up containers, I added `gnomock.StartNetwork` to explicitly add a network. When creating containers, use `gnomock.WithNetworkID` to tell the container to attach to a created network. After the test is done, use `gnomock.StopNetwork` to remove the network.