### PR TITLE
Allow users to set number of partitions in topic

### DIFF
--- a/preset/kafka/options.go
+++ b/preset/kafka/options.go
@@ -13,9 +13,19 @@ func WithVersion(version string) Option {
 
 // WithTopics makes sure that the provided topics are available when Kafka is
 // up and running.
+// Both topics from WithTopics and WithTopicConfigs will be added to Kafka.
 func WithTopics(topics ...string) Option {
 	return func(o *P) {
 		o.Topics = append(o.Topics, topics...)
+	}
+}
+
+// WithTopicConfigs makes sure that the provided topics with the given configs are available when Kafka is
+// up and running. Unlike WithTopics, this allows to also set partition count.
+// Both topics from WithTopics and WithTopicConfigs will be added to Kafka.
+func WithTopicConfigs(topics ...TopicConfig) Option {
+	return func(o *P) {
+		o.TopicConfigs = append(o.TopicConfigs, topics...)
 	}
 }
 


### PR DESCRIPTION
I have added new type, TopicConfig, and added it to options WithTopicConfig in backwards-compatible way.

For now it just has topic name and number of partitions, but it can be enhanced in the future with other options.

I wanted to also add a replication count, but there is just one broker in the cluster, so it makes no sense.

Fixes #1031