### PR TITLE
Fixing all goroutine leaks with client closings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,6 +37,8 @@ linters:
     - wsl
 
 issues:
+  include:
+    - EXC0001 # require error check on Close()
   exclude-rules:
     - path: _test\.go
       linters:

--- a/gnomock.go
+++ b/gnomock.go
@@ -114,6 +114,8 @@ func newContainer(g *g, image string, ports NamedPorts, config *Options) (c *Con
 		return nil, fmt.Errorf("can't create docker client: %w", err)
 	}
 
+	defer func() { _ = cli.stopClient() }()
+
 	c, err = cli.startContainer(ctx, image, ports, config)
 	if err != nil {
 		return nil, fmt.Errorf("can't start container: %w", err)
@@ -230,6 +232,8 @@ func (g *g) stop(c *Container) error {
 		return fmt.Errorf("can't create docker client: %w", err)
 	}
 
+	defer func() { _ = cli.stopClient() }()
+
 	id, sidecar := parseID(c.ID)
 	if sidecar != "" {
 		go func() {
@@ -237,6 +241,7 @@ func (g *g) stop(c *Container) error {
 			// error in this case won't matter, the container has a self-destruct
 			// timer
 			_ = cli.stopContainer(context.Background(), sidecar)
+			_ = cli.stopClient()
 		}()
 	}
 

--- a/gnomock_test.go
+++ b/gnomock_test.go
@@ -167,6 +167,7 @@ func TestGnomock_withDebugMode(t *testing.T) {
 	containerList, err = testutil.ListContainerByID(cli, container.ID)
 	require.NoError(t, err)
 	require.Len(t, containerList, 0)
+	require.NoError(t, cli.Close())
 }
 
 func TestGnomock_withLogWriter(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -26,20 +26,18 @@ require (
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/rabbitmq/amqp091-go v1.9.0
 	github.com/segmentio/kafka-go v0.4.47
 	github.com/stretchr/testify v1.9.0
 	go.mongodb.org/mongo-driver v1.15.0
+	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.10.0 // indirect
 	go.uber.org/zap v1.26.0
+	golang.org/x/mod v0.14.0
 	golang.org/x/sync v0.6.0
 	k8s.io/api v0.29.1
 	k8s.io/apimachinery v0.29.1
 	k8s.io/client-go v0.29.1
-)
-
-require (
-	github.com/rabbitmq/amqp091-go v1.9.0
-	golang.org/x/mod v0.14.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -323,8 +323,9 @@ go.opentelemetry.io/otel/trace v1.25.0 h1:tqukZGLwQYRIFtSQM2u2+yfMVTgGVeqRLPUYx1
 go.opentelemetry.io/otel/trace v1.25.0/go.mod h1:hCCs70XM/ljO+BeQkyFnbK28SBIJ/Emuha+ccrCRT7I=
 go.opentelemetry.io/proto/otlp v1.1.0 h1:2Di21piLrCqJ3U3eXGCTPHE9R8Nh+0uglSnOyxikMeI=
 go.opentelemetry.io/proto/otlp v1.1.0/go.mod h1:GpBHCBWiqvVLDqmHZsoMM3C5ySeKTC7ej/RNTae6MdY=
-go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
 go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
 go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.26.0 h1:sI7k6L95XOKS281NhVKOFCUNIvv9e0w4BF8N3u+tCRo=

--- a/internal/cleaner/cleaner_test.go
+++ b/internal/cleaner/cleaner_test.go
@@ -11,7 +11,13 @@ import (
 	"github.com/orlangure/gnomock/internal/health"
 	"github.com/orlangure/gnomock/internal/testutil"
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/goleak"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestCleaner(t *testing.T) {
 	t.Parallel()
@@ -53,6 +59,8 @@ func TestCleaner(t *testing.T) {
 	containerList, err = testutil.ListContainerByID(cli, cleanerContainer.ID)
 	require.NoError(t, err)
 	require.Len(t, containerList, 0)
+
+	require.NoError(t, cli.Close())
 }
 
 func TestCleaner_wrongRequest(t *testing.T) {

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -8,7 +8,13 @@ import (
 	"github.com/orlangure/gnomock"
 	"github.com/orlangure/gnomock/internal/errors"
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/goleak"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestPresetNotFoundError(t *testing.T) {
 	err := errors.NewPresetNotFoundError("invalid")

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -8,7 +8,13 @@ import (
 
 	"github.com/orlangure/gnomock/internal/health"
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/goleak"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestHTTPGet(t *testing.T) {
 	ctx := context.Background()

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -6,7 +6,12 @@ import (
 	"github.com/orlangure/gnomock"
 	"github.com/orlangure/gnomock/internal/registry"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 var p gnomock.Preset
 

--- a/preset/azurite/preset_test.go
+++ b/preset/azurite/preset_test.go
@@ -8,9 +8,14 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/orlangure/gnomock/preset/azurite"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 
 	"github.com/orlangure/gnomock"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestPreset_Blobstorage(t *testing.T) {
 	t.Parallel()

--- a/preset/cassandra/preset_test.go
+++ b/preset/cassandra/preset_test.go
@@ -7,7 +7,13 @@ import (
 	"github.com/orlangure/gnomock"
 	"github.com/orlangure/gnomock/preset/cassandra"
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/goleak"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestPreset(t *testing.T) {
 	t.Parallel()

--- a/preset/cockroachdb/preset.go
+++ b/preset/cockroachdb/preset.go
@@ -87,6 +87,10 @@ func (p *P) setDefaults() {
 func healthcheck(_ context.Context, c *gnomock.Container) error {
 	db, err := connect(c, "")
 	if err != nil {
+		if db != nil {
+			_ = db.Close()
+		}
+
 		return err
 	}
 
@@ -108,6 +112,7 @@ func (p *P) initf() gnomock.InitFunc {
 
 		_, err = db.Exec("create database " + p.DB)
 		if err != nil {
+			_ = db.Close()
 			return err
 		}
 

--- a/preset/cockroachdb/preset_test.go
+++ b/preset/cockroachdb/preset_test.go
@@ -8,7 +8,13 @@ import (
 	"github.com/orlangure/gnomock"
 	"github.com/orlangure/gnomock/preset/cockroachdb"
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/goleak"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestPreset(t *testing.T) {
 	t.Parallel()
@@ -54,6 +60,7 @@ func testPreset(version string) func(t *testing.T) {
 		require.Equal(t, float64(2), avg)
 		require.Equal(t, float64(1), min)
 		require.Equal(t, float64(3), count)
+		require.NoError(t, db.Close())
 	}
 }
 

--- a/preset/elastic/preset_test.go
+++ b/preset/elastic/preset_test.go
@@ -9,7 +9,13 @@ import (
 	"github.com/orlangure/gnomock"
 	"github.com/orlangure/gnomock/preset/elastic"
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/goleak"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 // these tests have trouble running in parallel, probably due to limited
 // resources

--- a/preset/influxdb/preset_test.go
+++ b/preset/influxdb/preset_test.go
@@ -10,7 +10,13 @@ import (
 	"github.com/orlangure/gnomock"
 	"github.com/orlangure/gnomock/preset/influxdb"
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/goleak"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestPreset(t *testing.T) {
 	for _, version := range []string{"alpine"} {
@@ -96,5 +102,6 @@ func testPreset(version string, useDefaults bool) func(t *testing.T) {
 		}
 
 		require.Contains(t, orgNames, org)
+		client.Close()
 	}
 }

--- a/preset/k3s/preset_test.go
+++ b/preset/k3s/preset_test.go
@@ -11,7 +11,13 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+
+	"go.uber.org/goleak"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestPreset(t *testing.T) {
 	t.Parallel()

--- a/preset/kafka/preset.go
+++ b/preset/kafka/preset.go
@@ -146,7 +146,8 @@ func (p *P) healthcheck(ctx context.Context, c *gnomock.Container) (err error) {
 	if err != nil {
 		return fmt.Errorf("can't create consumer group: %w", err)
 	}
-	defer group.Close()
+
+	defer func() { _ = group.Close() }()
 
 	if _, err := group.Next(ctx); err != nil {
 		return fmt.Errorf("can't read next consumer group: %w", err)

--- a/preset/kafka/preset_test.go
+++ b/preset/kafka/preset_test.go
@@ -10,7 +10,13 @@ import (
 	"github.com/orlangure/gnomock/preset/kafka"
 	kafkaclient "github.com/segmentio/kafka-go"
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/goleak"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestPreset(t *testing.T) {
 	versions := []string{"3.3.1-L0", "3.6.1-L0"}

--- a/preset/localstack/preset_test.go
+++ b/preset/localstack/preset_test.go
@@ -16,7 +16,13 @@ import (
 	"github.com/orlangure/gnomock"
 	"github.com/orlangure/gnomock/preset/localstack"
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/goleak"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestPreset_s3(t *testing.T) {
 	t.Parallel()

--- a/preset/mariadb/preset.go
+++ b/preset/mariadb/preset.go
@@ -91,6 +91,10 @@ func (p *P) healthcheck(_ context.Context, c *gnomock.Container) error {
 
 	db, err := p.connect(addr)
 	if err != nil {
+		if db != nil {
+			_ = db.Close()
+		}
+
 		return err
 	}
 

--- a/preset/mariadb/preset_test.go
+++ b/preset/mariadb/preset_test.go
@@ -8,7 +8,13 @@ import (
 	"github.com/orlangure/gnomock"
 	"github.com/orlangure/gnomock/preset/mariadb"
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/goleak"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestPreset(t *testing.T) {
 	t.Parallel()
@@ -61,6 +67,8 @@ func testPreset(version string) func(t *testing.T) {
 		require.Equal(t, float64(2), avg)
 		require.Equal(t, float64(1), min)
 		require.Equal(t, float64(3), count)
+
+		require.NoError(t, db.Close())
 	}
 }
 

--- a/preset/memcached/preset.go
+++ b/preset/memcached/preset.go
@@ -98,5 +98,7 @@ func healthcheck(_ context.Context, c *gnomock.Container) error {
 	addr := c.Address(gnomock.DefaultPort)
 	client := memcache.New(addr)
 
+	defer func() { _ = client.Close() }()
+
 	return client.Ping()
 }

--- a/preset/memcached/preset_test.go
+++ b/preset/memcached/preset_test.go
@@ -9,7 +9,13 @@ import (
 	"github.com/orlangure/gnomock"
 	"github.com/orlangure/gnomock/preset/memcached"
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/goleak"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestPreset(t *testing.T) {
 	t.Parallel()
@@ -69,6 +75,8 @@ func testPreset(version string) func(t *testing.T) {
 		itemD, err := client.Get("d")
 		require.NoError(t, err)
 		require.Equal(t, "foo", string(itemD.Value))
+
+		require.NoError(t, client.Close())
 	}
 }
 
@@ -85,4 +93,6 @@ func TestPreset_withDefaults(t *testing.T) {
 	addr := container.DefaultAddress()
 	client := memcachedclient.New(addr)
 	require.NoError(t, client.Ping())
+
+	require.NoError(t, client.Close())
 }

--- a/preset/mongo/preset.go
+++ b/preset/mongo/preset.go
@@ -103,6 +103,8 @@ func (p *P) initf(ctx context.Context, c *gnomock.Container) error {
 		return fmt.Errorf("can't create mongo client: %w", err)
 	}
 
+	defer func() { _ = client.Disconnect(ctx) }()
+
 	topLevelDirs, err := os.ReadDir(p.DataPath)
 	if err != nil {
 		return fmt.Errorf("can't read test data path: %w", err)
@@ -195,6 +197,8 @@ func healthcheck(ctx context.Context, c *gnomock.Container) error {
 	if err != nil {
 		return fmt.Errorf("can't create mongo client: %w", err)
 	}
+
+	defer func() { _ = client.Disconnect(ctx) }()
 
 	return client.Ping(ctx, nil)
 }

--- a/preset/mongo/preset_test.go
+++ b/preset/mongo/preset_test.go
@@ -12,7 +12,13 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	mongodb "go.mongodb.org/mongo-driver/mongo"
 	mongooptions "go.mongodb.org/mongo-driver/mongo/options"
+
+	"go.uber.org/goleak"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestPreset(t *testing.T) {
 	t.Parallel()
@@ -55,6 +61,8 @@ func testPreset(version string) func(t *testing.T) {
 		count, err = client.Database("db2").Collection("countries").CountDocuments(ctx, bson.D{})
 		require.NoError(t, err)
 		require.Equal(t, int64(3), count)
+
+		require.NoError(t, client.Disconnect(ctx))
 	}
 }
 

--- a/preset/mssql/preset.go
+++ b/preset/mssql/preset.go
@@ -104,17 +104,20 @@ func (p *P) initf() gnomock.InitFunc {
 			return err
 		}
 
-		defer func() { _ = db.Close() }()
-
 		_, err = db.Exec("create database " + p.DB)
 		if err != nil {
+			_ = db.Close()
 			return fmt.Errorf("can't create database '%s': %w", p.DB, err)
 		}
+
+		_ = db.Close()
 
 		db, err = p.connect(addr, p.DB)
 		if err != nil {
 			return err
 		}
+
+		defer func() { _ = db.Close() }()
 
 		if len(p.QueriesFiles) > 0 {
 			for _, f := range p.QueriesFiles {

--- a/preset/mssql/preset_test.go
+++ b/preset/mssql/preset_test.go
@@ -10,7 +10,13 @@ import (
 	"github.com/orlangure/gnomock"
 	"github.com/orlangure/gnomock/preset/mssql"
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/goleak"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestPreset(t *testing.T) {
 	t.Parallel()
@@ -63,6 +69,7 @@ func testPreset(version string) func(t *testing.T) {
 		require.Equal(t, float64(2), avg)
 		require.Equal(t, float64(1), min)
 		require.Equal(t, float64(3), count)
+		require.NoError(t, db.Close())
 	}
 }
 

--- a/preset/mysql/preset.go
+++ b/preset/mysql/preset.go
@@ -93,6 +93,10 @@ func (p *P) healthcheck(_ context.Context, c *gnomock.Container) error {
 
 	db, err := p.connect(addr)
 	if err != nil {
+		if db != nil {
+			_ = db.Close()
+		}
+
 		return err
 	}
 

--- a/preset/mysql/preset_test.go
+++ b/preset/mysql/preset_test.go
@@ -8,7 +8,13 @@ import (
 	"github.com/orlangure/gnomock"
 	"github.com/orlangure/gnomock/preset/mysql"
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/goleak"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestPreset(t *testing.T) {
 	t.Parallel()
@@ -59,6 +65,8 @@ func testPreset(version string) func(t *testing.T) {
 		require.Equal(t, float64(2), avg)
 		require.Equal(t, float64(1), min)
 		require.Equal(t, float64(3), count)
+
+		require.NoError(t, db.Close())
 	}
 }
 

--- a/preset/postgres/preset_test.go
+++ b/preset/postgres/preset_test.go
@@ -8,7 +8,13 @@ import (
 	"github.com/orlangure/gnomock"
 	"github.com/orlangure/gnomock/preset/postgres"
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/goleak"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestPreset(t *testing.T) {
 	t.Parallel()
@@ -63,6 +69,8 @@ func testPreset(version string) func(t *testing.T) {
 		timezoneRow := db.QueryRow("show timezone")
 		require.NoError(t, timezoneRow.Scan(&timezone))
 		require.Equal(t, "Europe/Paris", timezone)
+
+		require.NoError(t, db.Close())
 	}
 }
 

--- a/preset/rabbitmq/preset_test.go
+++ b/preset/rabbitmq/preset_test.go
@@ -12,7 +12,13 @@ import (
 	"github.com/orlangure/gnomock/preset/rabbitmq"
 	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/goleak"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestPreset(t *testing.T) {
 	versions := []string{

--- a/preset/redis/preset.go
+++ b/preset/redis/preset.go
@@ -60,6 +60,8 @@ func (p *P) Options() []gnomock.Option {
 			addr := c.Address(gnomock.DefaultPort)
 			client := redisclient.NewClient(&redisclient.Options{Addr: addr})
 
+			defer func() { _ = client.Close() }()
+
 			for k, v := range p.Values {
 				err := client.Set(k, v, 0).Err()
 				if err != nil {
@@ -85,6 +87,9 @@ func (p *P) setDefaults() {
 func healthcheck(_ context.Context, c *gnomock.Container) error {
 	addr := c.Address(gnomock.DefaultPort)
 	client := redisclient.NewClient(&redisclient.Options{Addr: addr})
+
+	defer func() { _ = client.Close() }()
+
 	_, err := client.Ping().Result()
 
 	return err

--- a/preset/redis/preset_test.go
+++ b/preset/redis/preset_test.go
@@ -7,7 +7,13 @@ import (
 	"github.com/orlangure/gnomock"
 	"github.com/orlangure/gnomock/preset/redis"
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/goleak"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestPreset(t *testing.T) {
 	t.Parallel()
@@ -52,6 +58,8 @@ func testPreset(version string) func(t *testing.T) {
 
 		require.NoError(t, client.Get("c").Scan(&flag))
 		require.True(t, flag)
+
+		require.NoError(t, client.Close())
 	}
 }
 

--- a/preset/splunk/preset.go
+++ b/preset/splunk/preset.go
@@ -144,7 +144,8 @@ func checkHEC(ctx context.Context, c *gnomock.Container) error {
 func insecureClient() http.Client {
 	return http.Client{
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+			TLSClientConfig:   &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+			DisableKeepAlives: true,
 		},
 	}
 }

--- a/preset/splunk/preset_test.go
+++ b/preset/splunk/preset_test.go
@@ -16,7 +16,13 @@ import (
 	"github.com/orlangure/gnomock"
 	"github.com/orlangure/gnomock/preset/splunk"
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/goleak"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestPreset(t *testing.T) {
 	events := make([]splunk.Event, 1000)
@@ -65,7 +71,8 @@ func TestPreset(t *testing.T) {
 	t.Run("initial values ingested", func(t *testing.T) {
 		client := &http.Client{
 			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+				TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
+				DisableKeepAlives: true,
 			},
 		}
 

--- a/preset/vault/preset_test.go
+++ b/preset/vault/preset_test.go
@@ -8,7 +8,13 @@ import (
 	"github.com/orlangure/gnomock"
 	"github.com/orlangure/gnomock/preset/vault"
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/goleak"
 )
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
 
 func TestPreset(t *testing.T) {
 	t.Parallel()

--- a/preset_test.go
+++ b/preset_test.go
@@ -34,6 +34,10 @@ func TestPreset_parallel(t *testing.T) {
 		require.NoError(t, health.HTTPGet(ctx, c.Address("web80")))
 		require.NoError(t, health.HTTPGet(ctx, c.Address("web8080")))
 	}
+
+	for _, c := range containers {
+		require.NoError(t, gnomock.Stop(c))
+	}
 }
 
 func TestPreset(t *testing.T) {
@@ -77,6 +81,8 @@ func TestPreset_containerRemainsIfDebug(t *testing.T) {
 	containerList, err := testutil.ListContainerByID(cli, container.ID)
 	require.NoError(t, err)
 	require.Len(t, containerList, 0)
+
+	require.NoError(t, cli.Close())
 }
 
 func TestPreset_duplicateContainerName(t *testing.T) {
@@ -106,6 +112,8 @@ func TestPreset_duplicateContainerName(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, containerList, 0)
 	require.NoError(t, gnomock.Stop(newContainer))
+
+	require.NoError(t, cli.Close())
 }
 
 func TestPreset_reusableContainerSucceeds(t *testing.T) {


### PR DESCRIPTION
Also adds uber's goroutine leaks checker to almost all tests.

The biggest change here is adding context to sidecar pull, which is then cancelled if the container creation fails. This prevents the sidecar goroutine from leaking. The same for making the sidecar channel buffered; the goroutine is not stuck when nobody reads from it. (It is not a memory leak either, GC will remove the channel.)

Other changes are just annoying work; putting client.Close() everywhere, db.Close() when Ping() is not successful, client closes in tests/presets, etc.

internal/gnomockd/ tests still show goroutine leaks for http transport, but I have no idea what is gnomockd even doing, let alone the tests, so I let that be.

Fixes #1035