### PR TITLE
Fix golangci-lint

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,18 +9,15 @@ jobs:
     name: "[core] lint"
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.21
-        uses: actions/setup-go@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: 1.21
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
-      - name: Get dependencies
-        run: go get -v -t -d ./...
-      - name: Get golangci-lint
-        run: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.57.2
-      - name: Lint
-        run: $(go env GOPATH)/bin/golangci-lint run --timeout 10m0s ./...
+          go-version: '1.21'
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.58.1
+          args: --timeout=10m
 
   test-core:
     name: "[core] gnomock, gnomockd"

--- a/preset/kafka/preset.go
+++ b/preset/kafka/preset.go
@@ -153,21 +153,29 @@ func (p *P) healthcheck(ctx context.Context, c *gnomock.Container) (err error) {
 	}
 
 	if p.UseSchemaRegistry {
-		url := "http://" + c.Address(SchemaRegistryPort)
-
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-		if err != nil {
-			return fmt.Errorf("invalid request: %w", err)
+		if err := p.healthcheckRegistry(ctx, c); err != nil {
+			return err
 		}
+	}
 
-		res, err := http.DefaultClient.Do(req)
-		if err != nil {
-			return fmt.Errorf("schema registry is not available: %w", err)
-		}
+	return nil
+}
 
-		if err := res.Body.Close(); err != nil {
-			return fmt.Errorf("error closing schema registry response body: %w", err)
-		}
+func (p *P) healthcheckRegistry(ctx context.Context, c *gnomock.Container) error {
+	url := "http://" + c.Address(SchemaRegistryPort)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("invalid request: %w", err)
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("schema registry is not available: %w", err)
+	}
+
+	if err := res.Body.Close(); err != nil {
+		return fmt.Errorf("error closing schema registry response body: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
Update golangci-lint (which fixes the weird timeout), also use the action (which caches the results for faster CI), also fixes all the issues reported.