### PR TITLE
Add custom image name configuration

### DIFF
--- a/gnomock.go
+++ b/gnomock.go
@@ -92,6 +92,10 @@ func StartCustom(image string, ports NamedPorts, opts ...Option) (*Container, er
 		ports = config.CustomNamedPorts
 	}
 
+	if config.CustomImage != "" {
+		image = config.CustomImage
+	}
+
 	g.log.Infow("starting", "image", image, "ports", ports)
 	g.log.Infow("using config", "image", image, "ports", ports, "config", config)
 

--- a/gnomock_test.go
+++ b/gnomock_test.go
@@ -366,6 +366,16 @@ func TestGnomock_withExtraHosts(t *testing.T) {
 	require.NoError(t, gnomock.Stop(container))
 }
 
+func TestGnomock_withCustomImage(t *testing.T) {
+	t.Parallel()
+
+	p := &testutil.TestPreset{Img: "docker.io/orlangure/noimage"}
+	container, err := gnomock.Start(p, gnomock.WithCustomImage(testutil.TestImage))
+	require.NoError(t, err)
+	require.NotNil(t, container)
+	require.NoError(t, gnomock.Stop(container))
+}
+
 func initf(context.Context, *gnomock.Container) error {
 	return nil
 }

--- a/options.go
+++ b/options.go
@@ -213,6 +213,14 @@ func WithExtraHosts(hosts []string) Option {
 	}
 }
 
+// WithCustomImage allows to define a custom image name. This option should be used to
+// override the image registry and repository defined by presets.
+func WithCustomImage(image string) Option {
+	return func(o *Options) {
+		o.CustomImage = image
+	}
+}
+
 // HealthcheckFunc defines a function to be used to determine container health.
 // It receives a host and a port, and returns an error if the container is not
 // ready, or nil when the container can be used. One example of HealthcheckFunc
@@ -306,6 +314,14 @@ type Options struct {
 	// Reuse prevents the container from being automatically stopped and enables
 	// its re-use in posterior executions.
 	Reuse bool `json:"reuse"`
+
+	// CustomImage allows to override the name of the image set by the presets
+	// with a custom image name. This option is useful for cases where it is
+	// required to pull the preset image from a custom registry and repository.
+	//
+	// Note that when using this option, you are responsible for verifying the
+	// validity of the provided image registry and repository.
+	CustomImage string `json:"customImage"`
 
 	ctx                 context.Context
 	init                InitFunc


### PR DESCRIPTION
## Changelog
- Enables the replacement of the image name of a preset via `WithCustomImage` function
- Fixes #1023 

## Details
Although I initially attempted to find a way to only replace the registry name, there wasn't a clean way to separate the registry name from the repository name. For example, the registry of the image `docker.io/library/mongo:latest` would be `docker.io/library` (everything before the last slash), whilst the registry for `docker.io/mysql/mysql-server:latest` would simply be `docker.io`. 

With such ambiguity, it would be better to let the user to define both the registry name and the repository name. (Also if one uses a custom registry, the subdirectories of the repository name would likely differ anyways)

Another way to implement this feature could be to redefine the internal representation of images from string to a custom type w/ internal fields for registry/repository/name, etc. However, this would require changing the image definitions for all presets, but may be more flexible in the long run.