### PR TITLE
fix(circleci): use default machine image for k3s tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,8 +172,7 @@ jobs:
           command: go test -race -cover -v ./internal/gnomockd -run TestMongo
 
   test-k3s:
-    machine:
-      image: ubuntu-2004:2022.04.2
+    machine: true
     resource_class: large
     steps:
       - setup-for-go-test


### PR DESCRIPTION
- Change k3s CircleCI job from ubuntu-2004:2022.04.2 to machine: true
- This aligns k3s with all other CircleCI jobs and may resolve test failures
- The specific Ubuntu image may have Docker/privileged container restrictions that interfere with k3s requiring privileged containers