### PR TITLE
Add support for private registry images in presets

### DIFF
--- a/preset/postgres/options.go
+++ b/preset/postgres/options.go
@@ -44,6 +44,13 @@ func WithVersion(version string) Option {
 	}
 }
 
+// WithImage sets image name
+func WithImage(name string) Option {
+	return func(o *P) {
+		o.ImageName = name
+	}
+}
+
 // WithTimezone sets the timezone in this container.
 func WithTimezone(timezone string) Option {
 	return func(p *P) {

--- a/preset/postgres/preset.go
+++ b/preset/postgres/preset.go
@@ -20,6 +20,7 @@ const (
 	defaultSSLMode  = "disable"
 	defaultPort     = 5432
 	defaultVersion  = "16.2"
+	defaultImage    = "docker.io/library/postgres"
 )
 
 func init() {
@@ -51,11 +52,12 @@ type P struct {
 	Password     string   `json:"password"`
 	Timezone     string   `json:"timezone"`
 	Version      string   `json:"version"`
+	ImageName    string   `json:"image_name"`
 }
 
 // Image returns an image that should be pulled to create this container.
 func (p *P) Image() string {
-	return fmt.Sprintf("docker.io/library/postgres:%s", p.Version)
+	return fmt.Sprintf("%s:%s", p.ImageName, p.Version)
 }
 
 // Ports returns ports that should be used to access this container.
@@ -150,6 +152,10 @@ func (p *P) setDefaults() {
 
 	if p.Version == "" {
 		p.Version = defaultVersion
+	}
+
+	if p.ImageName == "" {
+		p.ImageName = defaultImage
 	}
 }
 


### PR DESCRIPTION
### Summary
This PR adds first-class support for pulling container images from private registries

### Motivation
Gnomock is often used in CI and enterprise environments where base images are mirrored or hosted in private registries for security and reliability. Today, the Postgres preset hardcodes the Docker Hub library image, which makes using private registries cumbersome or impossible without custom forks.

Chages is fully backward-compatible:
- If `ImageName` is not set, the preset behaves exactly as before.
- Existing configs and tests do not need changes.

### Usage
- Continue using the preset as before for public images.
- To use a private registry, set `ImageName` to your registry path and keep `Version`:
  - Example: `WithImage("registry.example.com/team/postgres").WithVersion("16.2")`
- Authentication and access control rely on the testcontainers setup(via ENV for example)

## Request for early feedback
If maintainers are comfortable with this structure, I will implement the same pattern for other presets (e.g., MySQL, MongoDB, Redis, etc.) in this PR

### Open questions
- Is naming acceptible?
- Do you want a note in the preset README about private registry setup?