### PR TITLE
Add `gnomock.WithShmSize` option

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -344,6 +344,10 @@ func (d *docker) createContainer(
 		ExtraHosts:   cfg.ExtraHosts,
 	}
 
+	if cfg.ShmSize > 0 {
+		hostConfig.ShmSize = cfg.ShmSize
+	}
+
 	resp, err := d.client.ContainerCreate(ctx, containerConfig, hostConfig, nil, nil, cfg.ContainerName)
 	if err == nil {
 		return &resp, nil

--- a/gnomock_test.go
+++ b/gnomock_test.go
@@ -376,6 +376,32 @@ func TestGnomock_withCustomImage(t *testing.T) {
 	require.NoError(t, gnomock.Stop(container))
 }
 
+func TestGnomock_withShmSize(t *testing.T) {
+	t.Parallel()
+
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	require.NoError(t, err)
+	defer cli.Close()
+
+	const expectedShmSize = int64(256 * 1024 * 1024) // 256MB
+
+	container, err := gnomock.StartCustom(
+		testutil.TestImage,
+		gnomock.DefaultTCP(testutil.GoodPort80),
+		gnomock.WithShmSize(expectedShmSize),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, container)
+	defer func() {
+		require.NoError(t, gnomock.Stop(container))
+	}()
+
+	// Inspect the container to verify ShmSize was set correctly
+	containerJSON, err := cli.ContainerInspect(context.Background(), container.DockerID())
+	require.NoError(t, err)
+	require.Equal(t, expectedShmSize, containerJSON.HostConfig.ShmSize)
+}
+
 func initf(context.Context, *gnomock.Container) error {
 	return nil
 }

--- a/gnomock_test.go
+++ b/gnomock_test.go
@@ -381,7 +381,6 @@ func TestGnomock_withShmSize(t *testing.T) {
 
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	require.NoError(t, err)
-	defer cli.Close()
 
 	const expectedShmSize = int64(256 * 1024 * 1024) // 256MB
 
@@ -392,14 +391,14 @@ func TestGnomock_withShmSize(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NotNil(t, container)
-	defer func() {
-		require.NoError(t, gnomock.Stop(container))
-	}()
 
 	// Inspect the container to verify ShmSize was set correctly
 	containerJSON, err := cli.ContainerInspect(context.Background(), container.DockerID())
 	require.NoError(t, err)
 	require.Equal(t, expectedShmSize, containerJSON.HostConfig.ShmSize)
+
+	require.NoError(t, gnomock.Stop(container))
+	require.NoError(t, cli.Close())
 }
 
 func initf(context.Context, *gnomock.Container) error {

--- a/options.go
+++ b/options.go
@@ -230,6 +230,16 @@ func WithUser(user string) Option {
 	}
 }
 
+// WithShmSize sets the size of the shared memory (/dev/shm) in bytes. This is
+// equivalent to the --shm-size flag in docker run. Useful for applications that
+// need more shared memory than the default 64MB, such as PostgreSQL when using
+// large shared_buffers.
+func WithShmSize(size int64) Option {
+	return func(o *Options) {
+		o.ShmSize = size
+	}
+}
+
 // HealthcheckFunc defines a function to be used to determine container health.
 // It receives a host and a port, and returns an error if the container is not
 // ready, or nil when the container can be used. One example of HealthcheckFunc
@@ -335,6 +345,10 @@ type Options struct {
 	// User specifies the user:group or UID:GID that the container should run as.
 	// This is equivalent to the --user flag in docker run.
 	User string `json:"user"`
+
+	// ShmSize specifies the size of the shared memory (/dev/shm) in bytes.
+	// This is equivalent to the --shm-size flag in docker run.
+	ShmSize int64 `json:"shm_size"`
 
 	ctx                 context.Context
 	init                InitFunc

--- a/options.go
+++ b/options.go
@@ -233,7 +233,7 @@ func WithUser(user string) Option {
 // WithShmSize sets the size of the shared memory (/dev/shm) in bytes. This is
 // equivalent to the --shm-size flag in docker run. Useful for applications that
 // need more shared memory than the default 64MB, such as PostgreSQL when using
-// large shared_buffers.
+// large shared_buffers. If size is 0 or negative, the Docker default of 64MB will be used.
 func WithShmSize(size int64) Option {
 	return func(o *Options) {
 		o.ShmSize = size


### PR DESCRIPTION
This PR adds `gnomock.WithShmSize` option, allowing to configure a container’s shared memory size (just like Docker’s `--shm-size` flag).