### PR TITLE
fix(k3s): use Docker API to copy kubeconfig instead of HTTP

### DIFF
--- a/preset/k3s/preset.go
+++ b/preset/k3s/preset.go
@@ -29,17 +29,19 @@
 package k3s
 
 import (
+	"archive/tar"
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
 
+	"github.com/moby/moby/client"
 	"github.com/orlangure/gnomock"
 	"github.com/orlangure/gnomock/internal/registry"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -271,36 +273,19 @@ func (p *P) setDefaults() {
 
 // ConfigBytes returns file contents of kubeconfig file that should be used to
 // connect to the cluster running in the provided container.
-func ConfigBytes(c *gnomock.Container) (configBytes []byte, err error) {
+func ConfigBytes(c *gnomock.Container) ([]byte, error) {
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Docker client: %w", err)
+	}
+	defer cli.Close()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	url := fmt.Sprintf("http://%s/kubeconfig.yaml", c.Address(KubeConfigPortName))
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	configBytes, err := copyFileFromContainer(ctx, cli, c.ID, "/var/gnomock/kubeconfig.yaml")
 	if err != nil {
-		return nil, fmt.Errorf("kubeconfig unavailable: %w", err)
-	}
-
-	res, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("kubeconfig unavailable: %w", err)
-	}
-
-	defer func() {
-		closeErr := res.Body.Close()
-		if err == nil && closeErr != nil {
-			err = closeErr
-		}
-	}()
-
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("invalid kubeconfig response code '%d'", res.StatusCode)
-	}
-
-	configBytes, err = io.ReadAll(res.Body)
-	if err != nil {
-		return nil, fmt.Errorf("can't read kubeconfig body: %w", err)
+		return nil, fmt.Errorf("failed to get kubeconfig from container: %w", err)
 	}
 
 	configBytes = reServerAddress.ReplaceAll(
@@ -309,6 +294,26 @@ func ConfigBytes(c *gnomock.Container) (configBytes []byte, err error) {
 	)
 
 	return configBytes, nil
+}
+
+func copyFileFromContainer(ctx context.Context, cli *client.Client, containerID, srcPath string) ([]byte, error) {
+	reader, _, err := cli.CopyFromContainer(ctx, containerID, srcPath)
+	if err != nil {
+		return nil, fmt.Errorf("error copying file from container: %w", err)
+	}
+	defer reader.Close()
+
+	tr := tar.NewReader(reader)
+	if _, err = tr.Next(); err != nil {
+		return nil, fmt.Errorf("error reading tar header: %w", err)
+	}
+
+	buf := new(bytes.Buffer)
+	if _, err = io.Copy(buf, tr); err != nil {
+		return nil, fmt.Errorf("error reading file content: %w", err)
+	}
+
+	return buf.Bytes(), nil
 }
 
 // Config returns `*rest.Config` instance of Kubernetes client-go package. This


### PR DESCRIPTION
## Summary

`ConfigBytes` previously retrieved the kubeconfig by making an HTTP GET to a busybox httpd pod running inside the k3s container. This stopped working reliably: the httpd pod or its port mapping can be unavailable even when the cluster itself is healthy, causing `ConfigBytes` (and therefore `Config`) to fail intermittently.

This change replaces the HTTP fetch with a direct `CopyFromContainer` Docker API call that reads `/var/gnomock/kubeconfig.yaml` from the container filesystem. This is the same file that `K3S_KUBECONFIG_OUTPUT` instructs k3s to write, so it is available as soon as k3s starts — no httpd pod required.

Closes #1224